### PR TITLE
Support files with same package

### DIFF
--- a/micropb-gen/src/generator.rs
+++ b/micropb-gen/src/generator.rs
@@ -180,7 +180,7 @@ impl Generator {
         for file in &fdset.file {
             let code = self.generate_fdproto(file)?;
             if let Some(pkg_name) = file.package() {
-                *mod_tree.root.add_path(split_pkg_name(pkg_name)).value_mut() = Some(code);
+                mod_tree.root.add_path(split_pkg_name(pkg_name)).value_mut().get_or_insert(TokenStream::new()).extend(Some(code));
             } else {
                 mod_tree
                     .root

--- a/micropb-gen/src/generator.rs
+++ b/micropb-gen/src/generator.rs
@@ -180,7 +180,12 @@ impl Generator {
         for file in &fdset.file {
             let code = self.generate_fdproto(file)?;
             if let Some(pkg_name) = file.package() {
-                mod_tree.root.add_path(split_pkg_name(pkg_name)).value_mut().get_or_insert(TokenStream::new()).extend(Some(code));
+                mod_tree
+                    .root
+                    .add_path(split_pkg_name(pkg_name))
+                    .value_mut()
+                    .get_or_insert_with(TokenStream::new)
+                    .extend(code);
             } else {
                 mod_tree
                     .root

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -354,6 +354,16 @@ fn extension() {
         .unwrap();
 }
 
+fn files_with_same_package() {
+    let mut generator = Generator::new();
+    generator
+        .compile_protos(
+            &["proto/basic.proto", "proto/basic-dup.proto"],
+            std::env::var("OUT_DIR").unwrap() + "/files_with_same_package.rs",
+        )
+        .unwrap();
+}
+
 fn main() {
     no_config();
     boxed_and_option();
@@ -371,4 +381,5 @@ fn main() {
     conflicting_names();
     default_str_escape();
     extension();
+    files_with_same_package();
 }

--- a/tests/basic-proto/proto/basic-dup.proto
+++ b/tests/basic-proto/proto/basic-dup.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package basic;
+
+message BasicDup {
+    int32 x = 1;
+}

--- a/tests/basic-proto/src/files_with_same_package.rs
+++ b/tests/basic-proto/src/files_with_same_package.rs
@@ -1,0 +1,14 @@
+mod proto {
+    #![allow(clippy::all)]
+    #![allow(nonstandard_style, unused, irrefutable_let_patterns)]
+    include!(concat!(env!("OUT_DIR"), "/files_with_same_package.rs"));
+}
+
+#[test]
+fn same_package() {
+    let basic = proto::basic_::BasicTypes::default();
+    assert_eq!(basic.boolean(), None);
+
+    let basic_dup = proto::basic_::BasicDup::default();
+    assert_eq!(basic_dup.x, 0);
+}

--- a/tests/basic-proto/src/lib.rs
+++ b/tests/basic-proto/src/lib.rs
@@ -19,6 +19,8 @@ mod extension;
 #[cfg(test)]
 mod extern_import;
 #[cfg(test)]
+mod files_with_same_package;
+#[cfg(test)]
 mod implicit_presence;
 #[cfg(test)]
 mod int_type;


### PR DESCRIPTION
Two files may have the same package. For example:

```
// a.proto

syntax = "proto3";
package = "com.example.io"

message ExampleA {
    int32 val = 1;
}
```

```
// b.proto

syntax = "proto3";
package = "com.example.io"

message ExampleB {
    string val = 1;
}
```

I believe that currently, only one of these packages can be compiled using micropb-gen and "compile_protos".

My Rust is a bit shaky, and I was not able to get tests running locally (not sure why), but I believe this will address the above use case?