### PR TITLE
Improve APIs for message fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,13 @@ impl Example {
     /// Return mutable reference to f_int32 as an Option
     pub fn mut_f_int32(&mut self) -> Option<&mut i32>;
     /// Set value and presence of f_int32
-    pub fn set_f_int32(&mut self, val: i32);
+    pub fn set_f_int32(&mut self, val: i32) -> &mut Self;
     /// Clear presence of f_int32
-    pub fn clear_f_int32(&mut self);
+    pub fn clear_f_int32(&mut self) -> &mut Self;
+    /// Take f_int32 and return it
+    pub fn take_f_int32(&mut self) -> Option<i32>;
+    /// Builder method that sets f_int32. Useful for initializing the message.
+    pub fn init_f_int32(mut self, val: i32) -> Self;
 
     // Same APIs for other optional fields
 }
@@ -269,9 +273,9 @@ pub mod Example_ {
         /// Query presence of f_int32
         pub fn f_int32(&self) -> bool;
         /// Set presence of f_int32
-        pub fn set_f_int32(&mut self);
+        pub fn set_f_int32(&mut self) -> &mut Self;
         /// Clear presence of f_int32
-        pub fn clear_f_int32(&mut self);
+        pub fn clear_f_int32(&mut self) -> &mut Self;
         /// Builder method that toggles on the presence of f_int32. Useful for initializing the Hazzer.
         pub fn init_f_int32(mut self) -> Self;
 
@@ -282,7 +286,12 @@ pub mod Example_ {
 
 One big difference between `micropb` and other Protobuf libraries is that **`micropb` does not generate `Option` for optional fields**. This is because `Option<T>` takes up extra space for types like `i32` that don't have unused bits. Instead, `micropb` tracks the presence of all optional fields in a separate bitfield called a *hazzer*, which is usually small enough to fit into the message's padding. Field presence can either be queried directly from the hazzer or from message APIs that return `Option`.
 
-Note that a field will be considered empty (and ignored by the encoder) if its bit in the hazzer is not set, even if the field itself has been written. For example, the following is the proper way to initialize `Example` with all fields set:
+Note that a field will be considered empty (and ignored by the encoder) if its bit in the hazzer is not set, even if the field itself has been written. The following is an easy way to initialize a message with all optional fields set:
+```rust,ignore
+Example::default().init_f_int32(4).init_f_int64(-5).init_f_bool(true)
+```
+
+Alternatively, we can initialize the message using the constructor by manually setting the bits in the hazzer:
 ```rust,ignore
 Example {
     f_int32: 4,

--- a/micropb-gen/src/generator/field.rs
+++ b/micropb-gen/src/generator/field.rs
@@ -85,7 +85,7 @@ impl<'a> Field<'a> {
 
         let num = proto.number as u32;
         let name = &proto.name;
-        let (rust_name, raw_rust_name) = field_conf.config.rust_field_name(name)?;
+        let (rust_name, san_rust_name) = field_conf.config.rust_field_name(name)?;
         let boxed = field_conf.config.boxed.unwrap_or(false);
 
         let ftype = match (
@@ -143,7 +143,7 @@ impl<'a> Field<'a> {
             ftype,
             name,
             rust_name,
-            san_rust_name: raw_rust_name,
+            san_rust_name,
             default: proto.default_value().map(String::as_str),
             boxed,
             attrs,

--- a/micropb-gen/src/generator/field.rs
+++ b/micropb-gen/src/generator/field.rs
@@ -225,7 +225,9 @@ impl<'a> Field<'a> {
                 let muter_name = format_ident!("mut_{}", self.rust_name);
                 let clearer_name = format_ident!("clear_{}", self.rust_name);
                 let taker_name = format_ident!("take_{}", self.rust_name);
+                let init_name = format_ident!("init_{}", self.rust_name);
                 let fname = &self.san_rust_name;
+
                 let getter_doc =
                     format!("Return a reference to `{}` as an `Option`", self.rust_name);
                 let muter_doc = format!(
@@ -238,6 +240,11 @@ impl<'a> Field<'a> {
                     "Take the value of `{}` and clear its presence",
                     self.rust_name
                 );
+                let init_doc = format!(
+                    "Builder method that sets the value of `{}`. Useful for initializing the message.",
+                    self.rust_name
+                );
+
                 if let OptionalRepr::Hazzer = opt {
                     quote! {
                         #[doc = #getter_doc]
@@ -273,6 +280,13 @@ impl<'a> Field<'a> {
                             let val = self._has.#fname().then(|| ::core::mem::take(&mut self.#fname));
                             self._has.#clearer_name();
                             val
+                        }
+
+                        #[doc = #init_doc]
+                        #[inline]
+                        pub fn #init_name(mut self, value: #type_name) -> Self {
+                            self.#setter_name(value);
+                            self
                         }
                     }
                 } else {
@@ -313,6 +327,13 @@ impl<'a> Field<'a> {
                         pub fn #taker_name(&mut self) -> #wrapped_type {
                             self.#fname.take()
                         }
+
+                        #[doc = #init_doc]
+                        #[inline]
+                        pub fn #init_name(mut self, value: #type_name) -> Self {
+                            self.#setter_name(value);
+                            self
+                        }
                     }
                 }
             }
@@ -320,10 +341,16 @@ impl<'a> Field<'a> {
                 let type_name = type_spec.generate_rust_type(gen);
                 let setter_name = format_ident!("set_{}", self.rust_name);
                 let muter_name = format_ident!("mut_{}", self.rust_name);
+                let init_name = format_ident!("init_{}", self.rust_name);
                 let fname = &self.san_rust_name;
+
                 let getter_doc = format!("Return a reference to `{}`", self.rust_name);
                 let muter_doc = format!("Return a mutable reference to `{}`", self.rust_name);
                 let setter_doc = format!("Set the value of `{}`", self.rust_name);
+                let init_doc = format!(
+                    "Builder method that sets the value of `{}`. Useful for initializing the message.",
+                    self.rust_name
+                );
 
                 quote! {
                     #[doc = #getter_doc]
@@ -341,6 +368,13 @@ impl<'a> Field<'a> {
                     #[doc = #setter_doc]
                     #[inline]
                     pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
+                        self.#fname = value.into();
+                        self
+                    }
+
+                    #[doc = #init_doc]
+                    #[inline]
+                    pub fn #init_name(mut self, value: #type_name) -> Self {
                         self.#fname = value.into();
                         self
                     }

--- a/micropb-gen/src/generator/field.rs
+++ b/micropb-gen/src/generator/field.rs
@@ -217,107 +217,136 @@ impl<'a> Field<'a> {
     }
 
     pub(crate) fn generate_accessors(&self, gen: &Generator) -> TokenStream {
-        if let FieldType::Optional(type_spec, opt) = &self.ftype {
-            let type_name = type_spec.generate_rust_type(gen);
-            let wrapped_type = gen.wrapped_type(type_name.clone(), self.boxed, true);
-            let setter_name = format_ident!("set_{}", self.rust_name);
-            let muter_name = format_ident!("mut_{}", self.rust_name);
-            let clearer_name = format_ident!("clear_{}", self.rust_name);
-            let taker_name = format_ident!("take_{}", self.rust_name);
-            let fname = &self.san_rust_name;
+        match &self.ftype {
+            FieldType::Optional(type_spec, opt) => {
+                let type_name = type_spec.generate_rust_type(gen);
+                let wrapped_type = gen.wrapped_type(type_name.clone(), self.boxed, true);
+                let setter_name = format_ident!("set_{}", self.rust_name);
+                let muter_name = format_ident!("mut_{}", self.rust_name);
+                let clearer_name = format_ident!("clear_{}", self.rust_name);
+                let taker_name = format_ident!("take_{}", self.rust_name);
+                let fname = &self.san_rust_name;
+                let getter_doc =
+                    format!("Return a reference to `{}` as an `Option`", self.rust_name);
+                let muter_doc = format!(
+                    "Return a mutable reference to `{}` as an `Option`",
+                    self.rust_name
+                );
+                let setter_doc = format!("Set the value and presence of `{}`", self.rust_name);
+                let clearer_doc = format!("Clear the presence of `{}`", self.rust_name);
+                let taker_doc = format!(
+                    "Take the value of `{}` and clear its presence",
+                    self.rust_name
+                );
+                if let OptionalRepr::Hazzer = opt {
+                    quote! {
+                        #[doc = #getter_doc]
+                        #[inline]
+                        pub fn #fname(&self) -> ::core::option::Option<&#type_name> {
+                            self._has.#fname().then_some(&self.#fname)
+                        }
 
-            let getter_doc = format!("Return a reference to `{}` as an `Option`", self.rust_name);
-            let muter_doc = format!(
-                "Return a mutable reference to `{}` as an `Option`",
-                self.rust_name
-            );
-            let setter_doc = format!("Set the value and presence of `{}`", self.rust_name);
-            let clearer_doc = format!("Clear the presence of `{}`", self.rust_name);
-            let taker_doc = format!(
-                "Take the value of `{}` and clear its presence",
-                self.rust_name
-            );
+                        #[doc = #muter_doc]
+                        #[inline]
+                        pub fn #muter_name(&mut self) -> ::core::option::Option<&mut #type_name> {
+                            self._has.#fname().then_some(&mut self.#fname)
+                        }
 
-            // use value.into() to handle conversion into boxed and non-boxed fields
-            if let OptionalRepr::Hazzer = opt {
-                quote! {
-                    #[doc = #getter_doc]
-                    #[inline]
-                    pub fn #fname(&self) -> ::core::option::Option<&#type_name> {
-                        self._has.#fname().then_some(&self.#fname)
+                        #[doc = #setter_doc]
+                        #[inline]
+                        pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
+                            self._has.#setter_name();
+                            self.#fname = value.into();
+                            self
+                        }
+
+                        #[doc = #clearer_doc]
+                        #[inline]
+                        pub fn #clearer_name(&mut self) -> &mut Self {
+                            self._has.#clearer_name();
+                            self
+                        }
+
+                        #[doc = #taker_doc]
+                        #[inline]
+                        pub fn #taker_name(&mut self) -> #wrapped_type {
+                            let val = self._has.#fname().then(|| ::core::mem::take(&mut self.#fname));
+                            self._has.#clearer_name();
+                            val
+                        }
                     }
-
-                    #[doc = #muter_doc]
-                    #[inline]
-                    pub fn #muter_name(&mut self) -> ::core::option::Option<&mut #type_name> {
-                        self._has.#fname().then_some(&mut self.#fname)
-                    }
-
-                    #[doc = #setter_doc]
-                    #[inline]
-                    pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
-                        self._has.#setter_name();
-                        self.#fname = value.into();
-                        self
-                    }
-
-                    #[doc = #clearer_doc]
-                    #[inline]
-                    pub fn #clearer_name(&mut self) -> &mut Self {
-                        self._has.#clearer_name();
-                        self
-                    }
-
-                    #[doc = #taker_doc]
-                    #[inline]
-                    pub fn #taker_name(&mut self) -> #wrapped_type {
-                        let val = self._has.#fname().then(|| ::core::mem::take(&mut self.#fname));
-                        self._has.#clearer_name();
-                        val
-                    }
-                }
-            } else {
-                let (deref, deref_mut) = if self.boxed {
-                    (format_ident!("as_deref"), format_ident!("as_deref_mut"))
                 } else {
-                    (format_ident!("as_ref"), format_ident!("as_mut"))
-                };
-                quote! {
-                    #[doc = #getter_doc]
-                    #[inline]
-                    pub fn #fname(&self) -> ::core::option::Option<&#type_name> {
-                        self.#fname.#deref()
-                    }
+                    let (deref, deref_mut) = if self.boxed {
+                        (format_ident!("as_deref"), format_ident!("as_deref_mut"))
+                    } else {
+                        (format_ident!("as_ref"), format_ident!("as_mut"))
+                    };
+                    quote! {
+                        #[doc = #getter_doc]
+                        #[inline]
+                        pub fn #fname(&self) -> ::core::option::Option<&#type_name> {
+                            self.#fname.#deref()
+                        }
 
-                    #[doc = #muter_doc]
-                    #[inline]
-                    pub fn #muter_name(&mut self) -> ::core::option::Option<&mut #type_name> {
-                        self.#fname.#deref_mut()
-                    }
+                        #[doc = #muter_doc]
+                        #[inline]
+                        pub fn #muter_name(&mut self) -> ::core::option::Option<&mut #type_name> {
+                            self.#fname.#deref_mut()
+                        }
 
-                    #[doc = #setter_doc]
-                    #[inline]
-                    pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
-                        self.#fname = ::core::option::Option::Some(value.into());
-                        self
-                    }
+                        #[doc = #setter_doc]
+                        #[inline]
+                        pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
+                            self.#fname = ::core::option::Option::Some(value.into());
+                            self
+                        }
 
-                    #[doc = #clearer_doc]
-                    #[inline]
-                    pub fn #clearer_name(&mut self) -> &mut Self {
-                        self.#fname = ::core::option::Option::None;
-                        self
-                    }
+                        #[doc = #clearer_doc]
+                        #[inline]
+                        pub fn #clearer_name(&mut self) -> &mut Self {
+                            self.#fname = ::core::option::Option::None;
+                            self
+                        }
 
-                    #[doc = #taker_doc]
-                    #[inline]
-                    pub fn #taker_name(&mut self) -> #wrapped_type {
-                        self.#fname.take()
+                        #[doc = #taker_doc]
+                        #[inline]
+                        pub fn #taker_name(&mut self) -> #wrapped_type {
+                            self.#fname.take()
+                        }
                     }
                 }
             }
-        } else {
-            quote! {}
+            FieldType::Single(type_spec) => {
+                let type_name = type_spec.generate_rust_type(gen);
+                let setter_name = format_ident!("set_{}", self.rust_name);
+                let muter_name = format_ident!("mut_{}", self.rust_name);
+                let fname = &self.san_rust_name;
+                let getter_doc = format!("Return a reference to `{}`", self.rust_name);
+                let muter_doc = format!("Return a mutable reference to `{}`", self.rust_name);
+                let setter_doc = format!("Set the value of `{}`", self.rust_name);
+
+                quote! {
+                    #[doc = #getter_doc]
+                    #[inline]
+                    pub fn #fname(&self) -> &#type_name {
+                        &self.#fname
+                    }
+
+                    #[doc = #muter_doc]
+                    #[inline]
+                    pub fn #muter_name(&mut self) -> &mut #type_name {
+                        &mut self.#fname
+                    }
+
+                    #[doc = #setter_doc]
+                    #[inline]
+                    pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
+                        self.#fname = value.into();
+                        self
+                    }
+                }
+            }
+            _ => quote! {},
         }
     }
 

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -192,16 +192,18 @@ impl<'a> Message<'a> {
 
                 #[doc = #setter_doc]
                 #[inline]
-                pub fn #setter(&mut self) {
+                pub fn #setter(&mut self) -> &mut Self {
                     let elem = &mut self.0[#idx];
                     *elem |= #mask;
+                    self
                 }
 
                 #[doc = #clearer_doc]
                 #[inline]
-                pub fn #clearer(&mut self) {
+                pub fn #clearer(&mut self) -> &mut Self {
                     let elem = &mut self.0[#idx];
                     *elem &= !#mask;
+                    self
                 }
 
                 #[doc = #init_doc]

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -331,9 +331,11 @@ impl<'a> Message<'a> {
         let accessors = self.fields.iter().map(|f| {
             if let FieldType::Optional(type_spec, opt) = &f.ftype {
                 let type_name = type_spec.generate_rust_type(gen);
+                let wrapped_type = gen.wrapped_type(type_name.clone(), f.boxed, true);
                 let setter_name = format_ident!("set_{}", f.rust_name);
                 let muter_name = format_ident!("mut_{}", f.rust_name);
                 let clearer_name = format_ident!("clear_{}", f.rust_name);
+                let taker_name = format_ident!("take_{}", f.rust_name);
                 let fname = &f.san_rust_name;
 
                 let getter_doc = format!("Return a reference to `{}` as an `Option`", f.rust_name);
@@ -343,6 +345,8 @@ impl<'a> Message<'a> {
                 );
                 let setter_doc = format!("Set the value and presence of `{}`", f.rust_name);
                 let clearer_doc = format!("Clear the presence of `{}`", f.rust_name);
+                let taker_doc =
+                    format!("Take the value of `{}` and clear its presence", f.rust_name);
 
                 // use value.into() to handle conversion into boxed and non-boxed fields
                 if let OptionalRepr::Hazzer = opt {
@@ -361,15 +365,25 @@ impl<'a> Message<'a> {
 
                         #[doc = #setter_doc]
                         #[inline]
-                        pub fn #setter_name(&mut self, value: #type_name) {
+                        pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
                             self._has.#setter_name();
                             self.#fname = value.into();
+                            self
                         }
 
                         #[doc = #clearer_doc]
                         #[inline]
-                        pub fn #clearer_name(&mut self) {
+                        pub fn #clearer_name(&mut self) -> &mut Self {
                             self._has.#clearer_name();
+                            self
+                        }
+
+                        #[doc = #taker_doc]
+                        #[inline]
+                        pub fn #taker_name(&mut self) -> #wrapped_type {
+                            let val = self._has.#fname().then(|| ::core::mem::take(&mut self.#fname));
+                            self._has.#clearer_name();
+                            val
                         }
                     }
                 } else {
@@ -393,14 +407,22 @@ impl<'a> Message<'a> {
 
                         #[doc = #setter_doc]
                         #[inline]
-                        pub fn #setter_name(&mut self, value: #type_name) {
+                        pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
                             self.#fname = ::core::option::Option::Some(value.into());
+                            self
                         }
 
                         #[doc = #clearer_doc]
                         #[inline]
-                        pub fn #clearer_name(&mut self) {
+                        pub fn #clearer_name(&mut self) -> &mut Self {
                             self.#fname = ::core::option::Option::None;
+                            self
+                        }
+
+                        #[doc = #taker_doc]
+                        #[inline]
+                        pub fn #taker_name(&mut self) -> #wrapped_type {
+                            self.#fname.take()
                         }
                     }
                 }

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -5,7 +5,6 @@ use quote::{format_ident, quote};
 use syn::Ident;
 
 use crate::{
-    config::OptionalRepr,
     descriptor::DescriptorProto,
     generator::{
         field::{CustomField, FieldType},
@@ -330,109 +329,7 @@ impl<'a> Message<'a> {
     }
 
     pub(crate) fn generate_impl(&self, gen: &Generator) -> TokenStream {
-        let accessors = self.fields.iter().map(|f| {
-            if let FieldType::Optional(type_spec, opt) = &f.ftype {
-                let type_name = type_spec.generate_rust_type(gen);
-                let wrapped_type = gen.wrapped_type(type_name.clone(), f.boxed, true);
-                let setter_name = format_ident!("set_{}", f.rust_name);
-                let muter_name = format_ident!("mut_{}", f.rust_name);
-                let clearer_name = format_ident!("clear_{}", f.rust_name);
-                let taker_name = format_ident!("take_{}", f.rust_name);
-                let fname = &f.san_rust_name;
-
-                let getter_doc = format!("Return a reference to `{}` as an `Option`", f.rust_name);
-                let muter_doc = format!(
-                    "Return a mutable reference to `{}` as an `Option`",
-                    f.rust_name
-                );
-                let setter_doc = format!("Set the value and presence of `{}`", f.rust_name);
-                let clearer_doc = format!("Clear the presence of `{}`", f.rust_name);
-                let taker_doc =
-                    format!("Take the value of `{}` and clear its presence", f.rust_name);
-
-                // use value.into() to handle conversion into boxed and non-boxed fields
-                if let OptionalRepr::Hazzer = opt {
-                    quote! {
-                        #[doc = #getter_doc]
-                        #[inline]
-                        pub fn #fname(&self) -> ::core::option::Option<&#type_name> {
-                            self._has.#fname().then_some(&self.#fname)
-                        }
-
-                        #[doc = #muter_doc]
-                        #[inline]
-                        pub fn #muter_name(&mut self) -> ::core::option::Option<&mut #type_name> {
-                            self._has.#fname().then_some(&mut self.#fname)
-                        }
-
-                        #[doc = #setter_doc]
-                        #[inline]
-                        pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
-                            self._has.#setter_name();
-                            self.#fname = value.into();
-                            self
-                        }
-
-                        #[doc = #clearer_doc]
-                        #[inline]
-                        pub fn #clearer_name(&mut self) -> &mut Self {
-                            self._has.#clearer_name();
-                            self
-                        }
-
-                        #[doc = #taker_doc]
-                        #[inline]
-                        pub fn #taker_name(&mut self) -> #wrapped_type {
-                            let val = self._has.#fname().then(|| ::core::mem::take(&mut self.#fname));
-                            self._has.#clearer_name();
-                            val
-                        }
-                    }
-                } else {
-                    let (deref, deref_mut) = if f.boxed {
-                        (format_ident!("as_deref"), format_ident!("as_deref_mut"))
-                    } else {
-                        (format_ident!("as_ref"), format_ident!("as_mut"))
-                    };
-                    quote! {
-                        #[doc = #getter_doc]
-                        #[inline]
-                        pub fn #fname(&self) -> ::core::option::Option<&#type_name> {
-                            self.#fname.#deref()
-                        }
-
-                        #[doc = #muter_doc]
-                        #[inline]
-                        pub fn #muter_name(&mut self) -> ::core::option::Option<&mut #type_name> {
-                            self.#fname.#deref_mut()
-                        }
-
-                        #[doc = #setter_doc]
-                        #[inline]
-                        pub fn #setter_name(&mut self, value: #type_name) -> &mut Self {
-                            self.#fname = ::core::option::Option::Some(value.into());
-                            self
-                        }
-
-                        #[doc = #clearer_doc]
-                        #[inline]
-                        pub fn #clearer_name(&mut self) -> &mut Self {
-                            self.#fname = ::core::option::Option::None;
-                            self
-                        }
-
-                        #[doc = #taker_doc]
-                        #[inline]
-                        pub fn #taker_name(&mut self) -> #wrapped_type {
-                            self.#fname.take()
-                        }
-                    }
-                }
-            } else {
-                quote! {}
-            }
-        });
-
+        let accessors = self.fields.iter().map(|f| f.generate_accessors(gen));
         let name = &self.rust_name;
         let lifetime = &self.lifetime;
         quote! {

--- a/micropb/README.md
+++ b/micropb/README.md
@@ -253,9 +253,13 @@ impl Example {
     /// Return mutable reference to f_int32 as an Option
     pub fn mut_f_int32(&mut self) -> Option<&mut i32>;
     /// Set value and presence of f_int32
-    pub fn set_f_int32(&mut self, val: i32);
+    pub fn set_f_int32(&mut self, val: i32) -> &mut Self;
     /// Clear presence of f_int32
-    pub fn clear_f_int32(&mut self);
+    pub fn clear_f_int32(&mut self) -> &mut Self;
+    /// Take f_int32 and return it
+    pub fn take_f_int32(&mut self) -> Option<i32>;
+    /// Builder method that sets f_int32. Useful for initializing the message.
+    pub fn init_f_int32(mut self, val: i32) -> Self;
 
     // Same APIs for other optional fields
 }
@@ -269,9 +273,9 @@ pub mod Example_ {
         /// Query presence of f_int32
         pub fn f_int32(&self) -> bool;
         /// Set presence of f_int32
-        pub fn set_f_int32(&mut self);
+        pub fn set_f_int32(&mut self) -> &mut Self;
         /// Clear presence of f_int32
-        pub fn clear_f_int32(&mut self);
+        pub fn clear_f_int32(&mut self) -> &mut Self;
         /// Builder method that toggles on the presence of f_int32. Useful for initializing the Hazzer.
         pub fn init_f_int32(mut self) -> Self;
 
@@ -282,7 +286,12 @@ pub mod Example_ {
 
 One big difference between `micropb` and other Protobuf libraries is that **`micropb` does not generate `Option` for optional fields**. This is because `Option<T>` takes up extra space for types like `i32` that don't have unused bits. Instead, `micropb` tracks the presence of all optional fields in a separate bitfield called a *hazzer*, which is usually small enough to fit into the message's padding. Field presence can either be queried directly from the hazzer or from message APIs that return `Option`.
 
-Note that a field will be considered empty (and ignored by the encoder) if its bit in the hazzer is not set, even if the field itself has been written. For example, the following is the proper way to initialize `Example` with all fields set:
+Note that a field will be considered empty (and ignored by the encoder) if its bit in the hazzer is not set, even if the field itself has been written. The following is an easy way to initialize a message with all optional fields set:
+```rust,ignore
+Example::default().init_f_int32(4).init_f_int64(-5).init_f_bool(true)
+```
+
+Alternatively, we can initialize the message using the constructor by manually setting the bits in the hazzer:
 ```rust,ignore
 Example {
     f_int32: 4,

--- a/tests/basic-proto/src/boxed_and_option.rs
+++ b/tests/basic-proto/src/boxed_and_option.rs
@@ -18,6 +18,8 @@ fn boxed_and_option() {
     basic.set_boolean(true);
     assert_eq!(basic.boolean, Some(Box::new(true)));
     assert_eq!(basic.boolean(), Some(&true));
+    assert_eq!(basic.take_boolean(), Some(Box::new(true)));
+    assert_eq!(basic.take_boolean(), None);
 
     // Option<i32>
     assert_eq!(basic.int32_num, None);
@@ -25,6 +27,8 @@ fn boxed_and_option() {
     basic.set_int32_num(32);
     assert_eq!(basic.int32_num, Some(32));
     assert_eq!(basic.int32_num(), Some(&32));
+    assert_eq!(basic.take_int32_num(), Some(32));
+    assert_eq!(basic.take_int32_num(), None);
 
     // Box<u32>
     assert_eq!(basic.uint32_num, Box::new(0));
@@ -33,6 +37,8 @@ fn boxed_and_option() {
     assert_eq!(basic.uint32_num, Box::new(3));
     assert_eq!(basic.uint32_num(), Some(&3));
     assert!(basic._has.uint32_num());
+    assert_eq!(basic.take_uint32_num(), Some(Box::new(3)));
+    assert_eq!(basic.take_uint32_num(), None);
 }
 
 #[test]

--- a/tests/basic-proto/src/no_config.rs
+++ b/tests/basic-proto/src/no_config.rs
@@ -69,6 +69,18 @@ fn basic_msg() {
 }
 
 #[test]
+fn chain_init() {
+    let basic = proto::basic_::BasicTypes::default()
+        .init_boolean(true)
+        .init_int32_num(32)
+        .init_fixed32_num(10);
+    assert_eq!(basic.boolean(), Some(&true));
+    assert_eq!(basic.int32_num(), Some(&32));
+    assert_eq!(basic.fixed32_num(), Some(&10));
+    assert_eq!(basic.dbl(), None);
+}
+
+#[test]
 fn basic_type_check() {
     let basic = proto::basic_::BasicTypes::default();
     let _: i32 = basic.int32_num;


### PR DESCRIPTION
- Return `&mut self` from `set_` and `clear_` APIs
- Add `init_` and `take_` APIs to optional fields
- Add `set_`, `init_`, `mut_`, and getter APIs to singular fields