### PR TITLE
Manually generate PartialEq definitions instead of using derive

### DIFF
--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -384,7 +384,7 @@ config_decl! {
     /// repeated and `map` fields requires the elements to implement `Default`.
     no_default_impl: Option<bool>,
 
-    /// Disable generating `PartialEq` trait derives for message types.
+    /// Disable generating `PartialEq` trait impl for message types.
     no_partial_eq_impl: Option<bool>,
 
     /// Disable generating `Clone` trait derives for message types.

--- a/micropb-gen/src/generator.rs
+++ b/micropb-gen/src/generator.rs
@@ -351,6 +351,7 @@ impl Generator {
         let unknown_conf = msg_conf.next_conf("_unknown");
 
         let default = msg.generate_default_impl(self, hazzer_field_attr.is_some())?;
+        let partial_eq = msg.generate_partial_eq();
         let decl = msg.generate_decl(self, hazzer_field_attr, &unknown_conf)?;
         let msg_impl = msg.generate_impl(self);
         let decode = self
@@ -366,6 +367,7 @@ impl Generator {
             #msg_mod
             #decl
             #default
+            #partial_eq
             #msg_impl
             #decode
             #encode

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -199,13 +199,7 @@ fn container_alloc() {
 
 fn custom_field() {
     let mut generator = Generator::new();
-    generator.configure(
-        ".",
-        Config::new()
-            .no_debug_impl(true)
-            .no_clone_impl(true)
-            .no_partial_eq_impl(true),
-    );
+    generator.configure(".", Config::new().no_debug_impl(true).no_clone_impl(true));
     generator.configure(
         ".nested.Nested.inner",
         Config::new()

--- a/tests/basic-proto/src/container_heapless.rs
+++ b/tests/basic-proto/src/container_heapless.rs
@@ -65,6 +65,27 @@ fn map() {
 }
 
 #[test]
+fn partial_eq() {
+    let mut data1 = proto::Data::default();
+    let mut data2 = proto::Data::default();
+    assert_eq!(data1, data2);
+    data1.s = "x".try_into().unwrap();
+    assert_eq!(data1, data2);
+    data1._has.set_s();
+    assert_ne!(data1, data2);
+    data2.set_s("x".try_into().unwrap());
+    assert_eq!(data1, data2);
+
+    let mut list1 = proto::List::default();
+    let mut list2 = proto::List::default();
+    assert_eq!(list1, list2);
+    list1.list.push(proto::Data::default()).unwrap();
+    assert_ne!(list1, list2);
+    list2.list.push(proto::Data::default()).unwrap();
+    assert_eq!(list1, list2);
+}
+
+#[test]
 fn decode_string_bytes_cap() {
     let mut data = proto::Data::default();
     let mut decoder = PbDecoder::new(

--- a/tests/basic-proto/src/custom_field.rs
+++ b/tests/basic-proto/src/custom_field.rs
@@ -11,7 +11,7 @@ mod proto {
     include!(concat!(env!("OUT_DIR"), "/custom_field.rs"));
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 struct MockField {
     tags: Vec<Tag>,
 }
@@ -63,6 +63,16 @@ fn type_check() {
     // only one MockField
     assert_eq!(size_of::<proto::List>(), size_of::<MockField>());
     let _: MockField = list.list;
+}
+
+#[test]
+fn partial_eq() {
+    let nested1 = proto::nested_::Nested::default();
+    let mut nested2 = proto::nested_::Nested::default();
+    assert!(nested1 == nested2);
+
+    nested2.custom_inner.tags.push(Tag::from_parts(12, 4));
+    assert!(nested1 != nested2);
 }
 
 #[test]

--- a/tests/basic-proto/src/no_config.rs
+++ b/tests/basic-proto/src/no_config.rs
@@ -149,6 +149,25 @@ fn proto3() {
 }
 
 #[test]
+fn partial_eq() {
+    let non_opt1 = proto::basic3_::NonOptional::default();
+    let mut non_opt2 = proto::basic3_::NonOptional::default();
+    assert_eq!(non_opt1, non_opt2);
+    non_opt2.non_opt = 12;
+    assert_ne!(non_opt1, non_opt2);
+
+    let mut basic1 = proto::basic_::BasicTypes::default();
+    let mut basic2 = proto::basic_::BasicTypes::default();
+    assert_eq!(basic1, basic2);
+    basic2.int32_num = 12;
+    assert_eq!(basic1, basic2);
+    basic2._has.set_int32_num();
+    assert_ne!(basic1, basic2);
+    basic1._has.set_int32_num();
+    assert_ne!(basic1, basic2);
+}
+
+#[test]
 fn decode_varint() {
     let mut basic = proto::basic_::BasicTypes::default();
     let mut decoder = PbDecoder::new([3, 0x08, 0x96, 0x01].as_slice()); // field 1

--- a/tests/basic-proto/src/no_config.rs
+++ b/tests/basic-proto/src/no_config.rs
@@ -150,21 +150,37 @@ fn proto3() {
 
 #[test]
 fn partial_eq() {
+    // PartialEq with singular fields
     let non_opt1 = proto::basic3_::NonOptional::default();
     let mut non_opt2 = proto::basic3_::NonOptional::default();
     assert_eq!(non_opt1, non_opt2);
     non_opt2.non_opt = 12;
     assert_ne!(non_opt1, non_opt2);
 
+    // PartialEq with Hazzers
     let mut basic1 = proto::basic_::BasicTypes::default();
     let mut basic2 = proto::basic_::BasicTypes::default();
     assert_eq!(basic1, basic2);
     basic2.int32_num = 12;
+    // int32_num has no bearing on equality if the Hazzer bit is off
     assert_eq!(basic1, basic2);
     basic2._has.set_int32_num();
     assert_ne!(basic1, basic2);
     basic1._has.set_int32_num();
     assert_ne!(basic1, basic2);
+
+    // PartialEq with oneof fields
+    let mut nested1 = proto::nested_::Nested::default();
+    let mut nested2 = proto::nested_::Nested::default();
+    assert_eq!(nested1, nested2);
+    nested1.inner = Some(proto::nested_::Nested_::Inner::InnerMsg(
+        proto::nested_::Nested_::InnerMsg::default(),
+    ));
+    assert_ne!(nested1, nested2);
+    nested2.inner = Some(proto::nested_::Nested_::Inner::InnerMsg(
+        proto::nested_::Nested_::InnerMsg::default(),
+    ));
+    assert_eq!(nested1, nested2);
 }
 
 #[test]


### PR DESCRIPTION
Generates correct PartialEq logic for optional fields that use Hazzers