### PR TITLE
Revamp traits and configurations for container types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@
 - Add `ignore_wrong_len` flag to decoder
 - Add convenience methods for decoding and encoding
 - Add `MAX_SIZE` associated constant to `MessageEncode` trait, which statically computes the max size of a message on the wire
+- Add `PbBytes` trait and `bytes_type` configuration
+- Add `field_lifetime` configuration to set lifetime of message fields
 
 ### Changed
 
-- Bump MSRV to 1.83 for more const functions
+- Bump MSRV to 1.83 for const `Option::unwrap`
+- Remove `PbContainer` and change definitions of all container traits
+- Use string substitution for type and const params when configuring container types
 
 ### Fixed
 
 - Reject Protobuf Editions .proto files instead of pretending they're proto3
+- Fix lifetime detection for messages and oneofs
 
 ## [0.1.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Add `MAX_SIZE` associated constant to `MessageEncode` trait, which statically computes the max size of a message on the wire
 - Add `PbBytes` trait and `bytes_type` configuration
 - Add `field_lifetime` configuration to set lifetime of message fields
+- Add container trait impls for `Cow`
+- Add const constructor `_new` to hazzer structs and add const to all hazzer methods
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ gen.use_container_alloc();
 /*
 gen.configure(".",
     micropb_gen::Config::new()
-        .string_type("crate::MyString")
-        .vec_type("crate::MyVec")
-        .map_type("crate::MyMap")
+        .string_type("crate::MyString<$N>")
+        .bytes_type("crate::MyVec<u8, $N>")
+        .vec_type("crate::MyVec<$T, $N>")
+        .map_type("crate::MyMap<$K, $V, $N>")
 );
 */
 
@@ -232,7 +233,9 @@ pub struct Containers {
 }
 ```
 
-A container type is expected to implement `PbVec`, `PbString`, or `PbMap` from `micropb::container`, depending on what type of field it's used for. For convenience, `micropb` comes with built-in implementations of the container traits for types from [`heapless`](https://docs.rs/heapless/latest/heapless), [`arrayvec`](https://docs.rs/arrayvec/latest/arrayvec), and [`alloc`](https://doc.rust-lang.org/alloc) (see [Feature Flags](#feature-flags) for details).
+A container type is expected to implement `PbVec`, `PbString`, `PbBytes`, or `PbMap` from `micropb::container`, depending on what type of field it's used for. For convenience, `micropb` comes with built-in implementations of the container traits for types from [`heapless`](https://docs.rs/heapless/latest/heapless), [`arrayvec`](https://docs.rs/arrayvec/latest/arrayvec), and [`alloc`](https://doc.rust-lang.org/alloc) (see [Feature Flags](#feature-flags) for details).
+
+However, if only encoding logic is required, then the container traits are unnecessary. In that case, the only requirement for container types is that they dereference into `&[T]`, `&str`, and `&[u8]`, depending on what type of field it's for.
 
 ### Optional Fields
 

--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -404,7 +404,11 @@ config_decl! {
     /// // Will also automatically add the lifetime param to declaration of `Outer`
     /// gen.configure(".Outer.inner", Config::new().field_lifetime("'a"));
     /// ```
-    field_lifetime: [deref] Option<String>,
+    ///
+    /// # Note
+    /// This configuration is only applied to the path passed to `configure`. It is
+    /// not propagated to "children" paths.
+    [no_inherit] field_lifetime: [deref] Option<String>,
 
     // Type configs
 
@@ -560,7 +564,7 @@ impl Config {
         k: TokenStream,
         v: TokenStream,
         n: Option<u32>,
-    ) -> Result<Option<syn::Path>, String> {
+    ) -> Result<Option<syn::Type>, String> {
         self.map_type
             .as_ref()
             .map(|t| {

--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -242,8 +242,8 @@ config_decl! {
 
     /// Container type that's generated for `string` fields.
     ///
-    /// For decoding, the provided type must implement `PbBytes`. For encoding, the type must
-    /// implement `Deref<str>`.
+    /// For decoding, the provided type must implement `PbString + TryFrom<&str>`. For encoding,
+    /// the type must implement `Deref<str>`.
     ///
     /// If the provided type contains the sequence `$N`, it will be substituted for the value of
     /// [`max_bytes`](Config::max_bytes) if it's set for this field.
@@ -261,8 +261,8 @@ config_decl! {
 
     /// Container type that's generated for `bytes` fields.
     ///
-    /// For decoding, the provided type must implement `PbBytes`. For encoding, the type must
-    /// implement `Deref<[u8]>`.
+    /// For decoding, the provided type must implement `PbBytes + TryFrom<&[u8]>`. For encoding,
+    /// the type must implement `Deref<[u8]>`.
     ///
     /// If the provided type contains the sequence `$N`, it will be substituted for the value of
     /// [`max_bytes`](Config::max_bytes) if it's set for this field.

--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -280,7 +280,8 @@ config_decl! {
 
     /// Container type that's generated for `map` fields.
     ///
-    /// The provided type must implement `PbMap`.
+    /// For decoding, the provided type must implement `PbMap`. For encoding, the type must
+    /// implement `IntoIterator<Item = (&K, &V)>` for `&T`.
     ///
     /// If the provided type contains the sequence `$N`, it will be substituted for the value of
     /// [`max_bytes`](Config::max_bytes) if it's set for this field. Similarly, the sequences `$K`

--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -220,8 +220,8 @@ config_decl! {
 
     /// Container type that's generated for repeated fields.
     ///
-    /// For decoding, the provided type must implement `PbVec`. For encoding, the type must
-    /// implement `Deref<[T]>`.
+    /// For decoding, the provided type must implement `PbVec<T>`. For encoding, the type must
+    /// dereference into `[T]`, where `T` is the type of the element.
     ///
     /// If the provided type contains the sequence `$N`, it will be substituted for the value of
     /// [`max_bytes`](Config::max_bytes) if it's set for this field. Similarly, the sequence `$T`
@@ -243,7 +243,7 @@ config_decl! {
     /// Container type that's generated for `string` fields.
     ///
     /// For decoding, the provided type must implement `PbString + TryFrom<&str>`. For encoding,
-    /// the type must implement `Deref<str>`.
+    /// the type must dereference to `str`.
     ///
     /// If the provided type contains the sequence `$N`, it will be substituted for the value of
     /// [`max_bytes`](Config::max_bytes) if it's set for this field.
@@ -262,7 +262,7 @@ config_decl! {
     /// Container type that's generated for `bytes` fields.
     ///
     /// For decoding, the provided type must implement `PbBytes + TryFrom<&[u8]>`. For encoding,
-    /// the type must implement `Deref<[u8]>`.
+    /// the type must dereference to `[u8]`.
     ///
     /// If the provided type contains the sequence `$N`, it will be substituted for the value of
     /// [`max_bytes`](Config::max_bytes) if it's set for this field.

--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -376,8 +376,8 @@ config_decl! {
     /// ```
     ///
     /// # Note
-    /// This configuration is only applied to the path passed to `configure`. It is
-    /// not propagated to "children" paths.
+    /// This configuration is only applied to the path passed to
+    /// [`configure`](crate::Generator::configure). It is not propagated to "children" paths.
     [no_inherit] rename_field: [deref] Option<String>,
 
     /// Override the max size of the field on the wire.
@@ -407,8 +407,8 @@ config_decl! {
     /// ```
     ///
     /// # Note
-    /// This configuration is only applied to the path passed to `configure`. It is
-    /// not propagated to "children" paths.
+    /// This configuration is only applied to the path passed to
+    /// [`configure`](crate::Generator::configure). It is not propagated to "children" paths.
     [no_inherit] field_lifetime: [deref] Option<String>,
 
     // Type configs
@@ -465,8 +465,8 @@ config_decl! {
     /// like with [`custom_field`](Config::custom_field).
     ///
     /// # Note
-    /// This configuration is only applied to the path passed to `configure`. It is
-    /// not propagated to "children" paths.
+    /// This configuration is only applied to the path passed to
+    /// [`configure`](crate::Generator::configure). It is not propagated to "children" paths.
     [no_inherit] unknown_handler: [deref] Option<String>,
 
     // General configs

--- a/micropb-gen/src/config.rs
+++ b/micropb-gen/src/config.rs
@@ -405,11 +405,7 @@ config_decl! {
     /// // Will also automatically add the lifetime param to declaration of `Outer`
     /// gen.configure(".Outer.inner", Config::new().field_lifetime("'a"));
     /// ```
-    ///
-    /// # Note
-    /// This configuration is only applied to the path passed to
-    /// [`configure`](crate::Generator::configure). It is not propagated to "children" paths.
-    [no_inherit] field_lifetime: [deref] Option<String>,
+    field_lifetime: [deref] Option<String>,
 
     // Type configs
 

--- a/micropb-gen/src/descriptor.rs
+++ b/micropb-gen/src/descriptor.rs
@@ -18,7 +18,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -496,7 +496,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -894,7 +894,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -1088,7 +1088,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -1296,7 +1296,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -1799,7 +1799,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -2042,7 +2042,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -2943,7 +2943,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -3209,7 +3209,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -3396,7 +3396,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -3594,7 +3594,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -3892,7 +3892,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -4094,7 +4094,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -4576,7 +4576,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -6167,7 +6167,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -6823,7 +6823,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -7064,7 +7064,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -7436,7 +7436,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -8355,7 +8355,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -8607,7 +8607,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -8954,7 +8954,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -9316,7 +9316,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -9532,7 +9532,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -9829,7 +9829,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -10048,7 +10048,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -10535,7 +10535,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -11205,7 +11205,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -11532,7 +11532,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -11734,7 +11734,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -11969,7 +11969,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -12064,7 +12064,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -12419,7 +12419,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -12502,7 +12502,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;

--- a/micropb-gen/src/descriptor.rs
+++ b/micropb-gen/src/descriptor.rs
@@ -18,7 +18,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -496,7 +496,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -894,7 +894,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -1088,7 +1088,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -1296,7 +1296,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -1799,7 +1799,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -2042,7 +2042,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -2943,7 +2943,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -3209,7 +3209,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -3396,7 +3396,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -3594,7 +3594,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -3892,7 +3892,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -4094,7 +4094,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -4576,7 +4576,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -6167,7 +6167,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -6823,7 +6823,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -7064,7 +7064,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -7436,7 +7436,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -8355,7 +8355,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -8607,7 +8607,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -8954,7 +8954,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -9316,7 +9316,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -9532,7 +9532,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -9829,7 +9829,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -10048,7 +10048,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -10535,7 +10535,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -11205,7 +11205,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -11532,7 +11532,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -11734,7 +11734,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -11969,7 +11969,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -12064,7 +12064,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;
@@ -12419,7 +12419,7 @@ pub mod google_ {
                     decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                     let before = decoder.bytes_read();
                     while decoder.bytes_read() - before < len {
                         let tag = decoder.decode_tag()?;
@@ -12502,7 +12502,7 @@ pub mod google_ {
                 decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
                 len: usize,
             ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
-                use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
                 let before = decoder.bytes_read();
                 while decoder.bytes_read() - before < len {
                     let tag = decoder.decode_tag()?;

--- a/micropb-gen/src/descriptor.rs
+++ b/micropb-gen/src/descriptor.rs
@@ -49,153 +49,158 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `package`
                 #[inline]
-                pub fn r#package(&self) -> bool {
+                pub const fn r#package(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `package`
                 #[inline]
-                pub fn set_package(&mut self) -> &mut Self {
+                pub const fn set_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `package`
                 #[inline]
-                pub fn clear_package(&mut self) -> &mut Self {
+                pub const fn clear_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `package`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_package(mut self) -> Self {
+                pub const fn init_package(mut self) -> Self {
                     self.set_package();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
                 ///Query presence of `source_code_info`
                 #[inline]
-                pub fn r#source_code_info(&self) -> bool {
+                pub const fn r#source_code_info(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `source_code_info`
                 #[inline]
-                pub fn set_source_code_info(&mut self) -> &mut Self {
+                pub const fn set_source_code_info(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `source_code_info`
                 #[inline]
-                pub fn clear_source_code_info(&mut self) -> &mut Self {
+                pub const fn clear_source_code_info(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `source_code_info`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_source_code_info(mut self) -> Self {
+                pub const fn init_source_code_info(mut self) -> Self {
                     self.set_source_code_info();
                     self
                 }
                 ///Query presence of `syntax`
                 #[inline]
-                pub fn r#syntax(&self) -> bool {
+                pub const fn r#syntax(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `syntax`
                 #[inline]
-                pub fn set_syntax(&mut self) -> &mut Self {
+                pub const fn set_syntax(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `syntax`
                 #[inline]
-                pub fn clear_syntax(&mut self) -> &mut Self {
+                pub const fn clear_syntax(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `syntax`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_syntax(mut self) -> Self {
+                pub const fn init_syntax(mut self) -> Self {
                     self.set_syntax();
                     self
                 }
                 ///Query presence of `edition`
                 #[inline]
-                pub fn r#edition(&self) -> bool {
+                pub const fn r#edition(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `edition`
                 #[inline]
-                pub fn set_edition(&mut self) -> &mut Self {
+                pub const fn set_edition(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `edition`
                 #[inline]
-                pub fn clear_edition(&mut self) -> &mut Self {
+                pub const fn clear_edition(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `edition`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_edition(mut self) -> Self {
+                pub const fn init_edition(mut self) -> Self {
                     self.set_edition();
                     self
                 }
@@ -663,78 +668,83 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `start`
                     #[inline]
-                    pub fn r#start(&self) -> bool {
+                    pub const fn r#start(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `start`
                     #[inline]
-                    pub fn set_start(&mut self) -> &mut Self {
+                    pub const fn set_start(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `start`
                     #[inline]
-                    pub fn clear_start(&mut self) -> &mut Self {
+                    pub const fn clear_start(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `start`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_start(mut self) -> Self {
+                    pub const fn init_start(mut self) -> Self {
                         self.set_start();
                         self
                     }
                     ///Query presence of `end`
                     #[inline]
-                    pub fn r#end(&self) -> bool {
+                    pub const fn r#end(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `end`
                     #[inline]
-                    pub fn set_end(&mut self) -> &mut Self {
+                    pub const fn set_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `end`
                     #[inline]
-                    pub fn clear_end(&mut self) -> &mut Self {
+                    pub const fn clear_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `end`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_end(mut self) -> Self {
+                    pub const fn init_end(mut self) -> Self {
                         self.set_end();
                         self
                     }
                     ///Query presence of `options`
                     #[inline]
-                    pub fn r#options(&self) -> bool {
+                    pub const fn r#options(&self) -> bool {
                         (self.0[0] & 4) != 0
                     }
                     ///Set presence of `options`
                     #[inline]
-                    pub fn set_options(&mut self) -> &mut Self {
+                    pub const fn set_options(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 4;
                         self
                     }
                     ///Clear presence of `options`
                     #[inline]
-                    pub fn clear_options(&mut self) -> &mut Self {
+                    pub const fn clear_options(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !4;
                         self
                     }
                     ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_options(mut self) -> Self {
+                    pub const fn init_options(mut self) -> Self {
                         self.set_options();
                         self
                     }
@@ -935,53 +945,58 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `start`
                     #[inline]
-                    pub fn r#start(&self) -> bool {
+                    pub const fn r#start(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `start`
                     #[inline]
-                    pub fn set_start(&mut self) -> &mut Self {
+                    pub const fn set_start(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `start`
                     #[inline]
-                    pub fn clear_start(&mut self) -> &mut Self {
+                    pub const fn clear_start(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `start`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_start(mut self) -> Self {
+                    pub const fn init_start(mut self) -> Self {
                         self.set_start();
                         self
                     }
                     ///Query presence of `end`
                     #[inline]
-                    pub fn r#end(&self) -> bool {
+                    pub const fn r#end(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `end`
                     #[inline]
-                    pub fn set_end(&mut self) -> &mut Self {
+                    pub const fn set_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `end`
                     #[inline]
-                    pub fn clear_end(&mut self) -> &mut Self {
+                    pub const fn clear_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `end`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_end(mut self) -> Self {
+                    pub const fn init_end(mut self) -> Self {
                         self.set_end();
                         self
                     }
@@ -1121,53 +1136,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
@@ -1435,128 +1455,133 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `number`
                     #[inline]
-                    pub fn r#number(&self) -> bool {
+                    pub const fn r#number(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `number`
                     #[inline]
-                    pub fn set_number(&mut self) -> &mut Self {
+                    pub const fn set_number(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `number`
                     #[inline]
-                    pub fn clear_number(&mut self) -> &mut Self {
+                    pub const fn clear_number(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `number`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_number(mut self) -> Self {
+                    pub const fn init_number(mut self) -> Self {
                         self.set_number();
                         self
                     }
                     ///Query presence of `full_name`
                     #[inline]
-                    pub fn r#full_name(&self) -> bool {
+                    pub const fn r#full_name(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `full_name`
                     #[inline]
-                    pub fn set_full_name(&mut self) -> &mut Self {
+                    pub const fn set_full_name(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `full_name`
                     #[inline]
-                    pub fn clear_full_name(&mut self) -> &mut Self {
+                    pub const fn clear_full_name(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `full_name`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_full_name(mut self) -> Self {
+                    pub const fn init_full_name(mut self) -> Self {
                         self.set_full_name();
                         self
                     }
                     ///Query presence of `type`
                     #[inline]
-                    pub fn r#type(&self) -> bool {
+                    pub const fn r#type(&self) -> bool {
                         (self.0[0] & 4) != 0
                     }
                     ///Set presence of `type`
                     #[inline]
-                    pub fn set_type(&mut self) -> &mut Self {
+                    pub const fn set_type(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 4;
                         self
                     }
                     ///Clear presence of `type`
                     #[inline]
-                    pub fn clear_type(&mut self) -> &mut Self {
+                    pub const fn clear_type(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !4;
                         self
                     }
                     ///Builder method that sets the presence of `type`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_type(mut self) -> Self {
+                    pub const fn init_type(mut self) -> Self {
                         self.set_type();
                         self
                     }
                     ///Query presence of `reserved`
                     #[inline]
-                    pub fn r#reserved(&self) -> bool {
+                    pub const fn r#reserved(&self) -> bool {
                         (self.0[0] & 8) != 0
                     }
                     ///Set presence of `reserved`
                     #[inline]
-                    pub fn set_reserved(&mut self) -> &mut Self {
+                    pub const fn set_reserved(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 8;
                         self
                     }
                     ///Clear presence of `reserved`
                     #[inline]
-                    pub fn clear_reserved(&mut self) -> &mut Self {
+                    pub const fn clear_reserved(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !8;
                         self
                     }
                     ///Builder method that sets the presence of `reserved`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_reserved(mut self) -> Self {
+                    pub const fn init_reserved(mut self) -> Self {
                         self.set_reserved();
                         self
                     }
                     ///Query presence of `repeated`
                     #[inline]
-                    pub fn r#repeated(&self) -> bool {
+                    pub const fn r#repeated(&self) -> bool {
                         (self.0[0] & 16) != 0
                     }
                     ///Set presence of `repeated`
                     #[inline]
-                    pub fn set_repeated(&mut self) -> &mut Self {
+                    pub const fn set_repeated(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 16;
                         self
                     }
                     ///Clear presence of `repeated`
                     #[inline]
-                    pub fn clear_repeated(&mut self) -> &mut Self {
+                    pub const fn clear_repeated(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !16;
                         self
                     }
                     ///Builder method that sets the presence of `repeated`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_repeated(mut self) -> Self {
+                    pub const fn init_repeated(mut self) -> Self {
                         self.set_repeated();
                         self
                     }
@@ -1873,53 +1898,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
                 ///Query presence of `verification`
                 #[inline]
-                pub fn r#verification(&self) -> bool {
+                pub const fn r#verification(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `verification`
                 #[inline]
-                pub fn set_verification(&mut self) -> &mut Self {
+                pub const fn set_verification(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `verification`
                 #[inline]
-                pub fn clear_verification(&mut self) -> &mut Self {
+                pub const fn clear_verification(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `verification`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_verification(mut self) -> Self {
+                pub const fn init_verification(mut self) -> Self {
                     self.set_verification();
                     self
                 }
@@ -2156,278 +2186,283 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 2]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 2])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `number`
                 #[inline]
-                pub fn r#number(&self) -> bool {
+                pub const fn r#number(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `number`
                 #[inline]
-                pub fn set_number(&mut self) -> &mut Self {
+                pub const fn set_number(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `number`
                 #[inline]
-                pub fn clear_number(&mut self) -> &mut Self {
+                pub const fn clear_number(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `number`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_number(mut self) -> Self {
+                pub const fn init_number(mut self) -> Self {
                     self.set_number();
                     self
                 }
                 ///Query presence of `label`
                 #[inline]
-                pub fn r#label(&self) -> bool {
+                pub const fn r#label(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `label`
                 #[inline]
-                pub fn set_label(&mut self) -> &mut Self {
+                pub const fn set_label(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `label`
                 #[inline]
-                pub fn clear_label(&mut self) -> &mut Self {
+                pub const fn clear_label(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `label`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_label(mut self) -> Self {
+                pub const fn init_label(mut self) -> Self {
                     self.set_label();
                     self
                 }
                 ///Query presence of `type`
                 #[inline]
-                pub fn r#type(&self) -> bool {
+                pub const fn r#type(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `type`
                 #[inline]
-                pub fn set_type(&mut self) -> &mut Self {
+                pub const fn set_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `type`
                 #[inline]
-                pub fn clear_type(&mut self) -> &mut Self {
+                pub const fn clear_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `type`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_type(mut self) -> Self {
+                pub const fn init_type(mut self) -> Self {
                     self.set_type();
                     self
                 }
                 ///Query presence of `type_name`
                 #[inline]
-                pub fn r#type_name(&self) -> bool {
+                pub const fn r#type_name(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `type_name`
                 #[inline]
-                pub fn set_type_name(&mut self) -> &mut Self {
+                pub const fn set_type_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `type_name`
                 #[inline]
-                pub fn clear_type_name(&mut self) -> &mut Self {
+                pub const fn clear_type_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `type_name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_type_name(mut self) -> Self {
+                pub const fn init_type_name(mut self) -> Self {
                     self.set_type_name();
                     self
                 }
                 ///Query presence of `extendee`
                 #[inline]
-                pub fn r#extendee(&self) -> bool {
+                pub const fn r#extendee(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `extendee`
                 #[inline]
-                pub fn set_extendee(&mut self) -> &mut Self {
+                pub const fn set_extendee(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `extendee`
                 #[inline]
-                pub fn clear_extendee(&mut self) -> &mut Self {
+                pub const fn clear_extendee(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `extendee`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_extendee(mut self) -> Self {
+                pub const fn init_extendee(mut self) -> Self {
                     self.set_extendee();
                     self
                 }
                 ///Query presence of `default_value`
                 #[inline]
-                pub fn r#default_value(&self) -> bool {
+                pub const fn r#default_value(&self) -> bool {
                     (self.0[0] & 64) != 0
                 }
                 ///Set presence of `default_value`
                 #[inline]
-                pub fn set_default_value(&mut self) -> &mut Self {
+                pub const fn set_default_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 64;
                     self
                 }
                 ///Clear presence of `default_value`
                 #[inline]
-                pub fn clear_default_value(&mut self) -> &mut Self {
+                pub const fn clear_default_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !64;
                     self
                 }
                 ///Builder method that sets the presence of `default_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_default_value(mut self) -> Self {
+                pub const fn init_default_value(mut self) -> Self {
                     self.set_default_value();
                     self
                 }
                 ///Query presence of `oneof_index`
                 #[inline]
-                pub fn r#oneof_index(&self) -> bool {
+                pub const fn r#oneof_index(&self) -> bool {
                     (self.0[0] & 128) != 0
                 }
                 ///Set presence of `oneof_index`
                 #[inline]
-                pub fn set_oneof_index(&mut self) -> &mut Self {
+                pub const fn set_oneof_index(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 128;
                     self
                 }
                 ///Clear presence of `oneof_index`
                 #[inline]
-                pub fn clear_oneof_index(&mut self) -> &mut Self {
+                pub const fn clear_oneof_index(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !128;
                     self
                 }
                 ///Builder method that sets the presence of `oneof_index`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_oneof_index(mut self) -> Self {
+                pub const fn init_oneof_index(mut self) -> Self {
                     self.set_oneof_index();
                     self
                 }
                 ///Query presence of `json_name`
                 #[inline]
-                pub fn r#json_name(&self) -> bool {
+                pub const fn r#json_name(&self) -> bool {
                     (self.0[1] & 1) != 0
                 }
                 ///Set presence of `json_name`
                 #[inline]
-                pub fn set_json_name(&mut self) -> &mut Self {
+                pub const fn set_json_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `json_name`
                 #[inline]
-                pub fn clear_json_name(&mut self) -> &mut Self {
+                pub const fn clear_json_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `json_name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_json_name(mut self) -> Self {
+                pub const fn init_json_name(mut self) -> Self {
                     self.set_json_name();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[1] & 2) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
                 ///Query presence of `proto3_optional`
                 #[inline]
-                pub fn r#proto3_optional(&self) -> bool {
+                pub const fn r#proto3_optional(&self) -> bool {
                     (self.0[1] & 4) != 0
                 }
                 ///Set presence of `proto3_optional`
                 #[inline]
-                pub fn set_proto3_optional(&mut self) -> &mut Self {
+                pub const fn set_proto3_optional(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `proto3_optional`
                 #[inline]
-                pub fn clear_proto3_optional(&mut self) -> &mut Self {
+                pub const fn clear_proto3_optional(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `proto3_optional`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_proto3_optional(mut self) -> Self {
+                pub const fn init_proto3_optional(mut self) -> Self {
                     self.set_proto3_optional();
                     self
                 }
@@ -3052,53 +3087,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
@@ -3243,53 +3283,58 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `start`
                     #[inline]
-                    pub fn r#start(&self) -> bool {
+                    pub const fn r#start(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `start`
                     #[inline]
-                    pub fn set_start(&mut self) -> &mut Self {
+                    pub const fn set_start(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `start`
                     #[inline]
-                    pub fn clear_start(&mut self) -> &mut Self {
+                    pub const fn clear_start(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `start`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_start(mut self) -> Self {
+                    pub const fn init_start(mut self) -> Self {
                         self.set_start();
                         self
                     }
                     ///Query presence of `end`
                     #[inline]
-                    pub fn r#end(&self) -> bool {
+                    pub const fn r#end(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `end`
                     #[inline]
-                    pub fn set_end(&mut self) -> &mut Self {
+                    pub const fn set_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `end`
                     #[inline]
-                    pub fn clear_end(&mut self) -> &mut Self {
+                    pub const fn clear_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `end`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_end(mut self) -> Self {
+                    pub const fn init_end(mut self) -> Self {
                         self.set_end();
                         self
                     }
@@ -3429,53 +3474,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
@@ -3667,78 +3717,83 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `number`
                 #[inline]
-                pub fn r#number(&self) -> bool {
+                pub const fn r#number(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `number`
                 #[inline]
-                pub fn set_number(&mut self) -> &mut Self {
+                pub const fn set_number(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `number`
                 #[inline]
-                pub fn clear_number(&mut self) -> &mut Self {
+                pub const fn clear_number(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `number`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_number(mut self) -> Self {
+                pub const fn init_number(mut self) -> Self {
                     self.set_number();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
@@ -3933,53 +3988,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
@@ -4140,153 +4200,158 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `name`
                 #[inline]
-                pub fn r#name(&self) -> bool {
+                pub const fn r#name(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `name`
                 #[inline]
-                pub fn set_name(&mut self) -> &mut Self {
+                pub const fn set_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `name`
                 #[inline]
-                pub fn clear_name(&mut self) -> &mut Self {
+                pub const fn clear_name(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `name`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_name(mut self) -> Self {
+                pub const fn init_name(mut self) -> Self {
                     self.set_name();
                     self
                 }
                 ///Query presence of `input_type`
                 #[inline]
-                pub fn r#input_type(&self) -> bool {
+                pub const fn r#input_type(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `input_type`
                 #[inline]
-                pub fn set_input_type(&mut self) -> &mut Self {
+                pub const fn set_input_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `input_type`
                 #[inline]
-                pub fn clear_input_type(&mut self) -> &mut Self {
+                pub const fn clear_input_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `input_type`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_input_type(mut self) -> Self {
+                pub const fn init_input_type(mut self) -> Self {
                     self.set_input_type();
                     self
                 }
                 ///Query presence of `output_type`
                 #[inline]
-                pub fn r#output_type(&self) -> bool {
+                pub const fn r#output_type(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `output_type`
                 #[inline]
-                pub fn set_output_type(&mut self) -> &mut Self {
+                pub const fn set_output_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `output_type`
                 #[inline]
-                pub fn clear_output_type(&mut self) -> &mut Self {
+                pub const fn clear_output_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `output_type`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_output_type(mut self) -> Self {
+                pub const fn init_output_type(mut self) -> Self {
                     self.set_output_type();
                     self
                 }
                 ///Query presence of `options`
                 #[inline]
-                pub fn r#options(&self) -> bool {
+                pub const fn r#options(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `options`
                 #[inline]
-                pub fn set_options(&mut self) -> &mut Self {
+                pub const fn set_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `options`
                 #[inline]
-                pub fn clear_options(&mut self) -> &mut Self {
+                pub const fn clear_options(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `options`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_options(mut self) -> Self {
+                pub const fn init_options(mut self) -> Self {
                     self.set_options();
                     self
                 }
                 ///Query presence of `client_streaming`
                 #[inline]
-                pub fn r#client_streaming(&self) -> bool {
+                pub const fn r#client_streaming(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `client_streaming`
                 #[inline]
-                pub fn set_client_streaming(&mut self) -> &mut Self {
+                pub const fn set_client_streaming(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `client_streaming`
                 #[inline]
-                pub fn clear_client_streaming(&mut self) -> &mut Self {
+                pub const fn clear_client_streaming(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `client_streaming`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_client_streaming(mut self) -> Self {
+                pub const fn init_client_streaming(mut self) -> Self {
                     self.set_client_streaming();
                     self
                 }
                 ///Query presence of `server_streaming`
                 #[inline]
-                pub fn r#server_streaming(&self) -> bool {
+                pub const fn r#server_streaming(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `server_streaming`
                 #[inline]
-                pub fn set_server_streaming(&mut self) -> &mut Self {
+                pub const fn set_server_streaming(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `server_streaming`
                 #[inline]
-                pub fn clear_server_streaming(&mut self) -> &mut Self {
+                pub const fn clear_server_streaming(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `server_streaming`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_server_streaming(mut self) -> Self {
+                pub const fn init_server_streaming(mut self) -> Self {
                     self.set_server_streaming();
                     self
                 }
@@ -4659,503 +4724,510 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 3]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 3])
+                }
                 ///Query presence of `java_package`
                 #[inline]
-                pub fn r#java_package(&self) -> bool {
+                pub const fn r#java_package(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `java_package`
                 #[inline]
-                pub fn set_java_package(&mut self) -> &mut Self {
+                pub const fn set_java_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `java_package`
                 #[inline]
-                pub fn clear_java_package(&mut self) -> &mut Self {
+                pub const fn clear_java_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `java_package`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_java_package(mut self) -> Self {
+                pub const fn init_java_package(mut self) -> Self {
                     self.set_java_package();
                     self
                 }
                 ///Query presence of `java_outer_classname`
                 #[inline]
-                pub fn r#java_outer_classname(&self) -> bool {
+                pub const fn r#java_outer_classname(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `java_outer_classname`
                 #[inline]
-                pub fn set_java_outer_classname(&mut self) -> &mut Self {
+                pub const fn set_java_outer_classname(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `java_outer_classname`
                 #[inline]
-                pub fn clear_java_outer_classname(&mut self) -> &mut Self {
+                pub const fn clear_java_outer_classname(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `java_outer_classname`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_java_outer_classname(mut self) -> Self {
+                pub const fn init_java_outer_classname(mut self) -> Self {
                     self.set_java_outer_classname();
                     self
                 }
                 ///Query presence of `java_multiple_files`
                 #[inline]
-                pub fn r#java_multiple_files(&self) -> bool {
+                pub const fn r#java_multiple_files(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `java_multiple_files`
                 #[inline]
-                pub fn set_java_multiple_files(&mut self) -> &mut Self {
+                pub const fn set_java_multiple_files(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `java_multiple_files`
                 #[inline]
-                pub fn clear_java_multiple_files(&mut self) -> &mut Self {
+                pub const fn clear_java_multiple_files(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `java_multiple_files`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_java_multiple_files(mut self) -> Self {
+                pub const fn init_java_multiple_files(mut self) -> Self {
                     self.set_java_multiple_files();
                     self
                 }
                 ///Query presence of `java_generate_equals_and_hash`
                 #[inline]
-                pub fn r#java_generate_equals_and_hash(&self) -> bool {
+                pub const fn r#java_generate_equals_and_hash(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `java_generate_equals_and_hash`
                 #[inline]
-                pub fn set_java_generate_equals_and_hash(&mut self) -> &mut Self {
+                pub const fn set_java_generate_equals_and_hash(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `java_generate_equals_and_hash`
                 #[inline]
-                pub fn clear_java_generate_equals_and_hash(&mut self) -> &mut Self {
+                pub const fn clear_java_generate_equals_and_hash(
+                    &mut self,
+                ) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `java_generate_equals_and_hash`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_java_generate_equals_and_hash(mut self) -> Self {
+                pub const fn init_java_generate_equals_and_hash(mut self) -> Self {
                     self.set_java_generate_equals_and_hash();
                     self
                 }
                 ///Query presence of `java_string_check_utf8`
                 #[inline]
-                pub fn r#java_string_check_utf8(&self) -> bool {
+                pub const fn r#java_string_check_utf8(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `java_string_check_utf8`
                 #[inline]
-                pub fn set_java_string_check_utf8(&mut self) -> &mut Self {
+                pub const fn set_java_string_check_utf8(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `java_string_check_utf8`
                 #[inline]
-                pub fn clear_java_string_check_utf8(&mut self) -> &mut Self {
+                pub const fn clear_java_string_check_utf8(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `java_string_check_utf8`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_java_string_check_utf8(mut self) -> Self {
+                pub const fn init_java_string_check_utf8(mut self) -> Self {
                     self.set_java_string_check_utf8();
                     self
                 }
                 ///Query presence of `optimize_for`
                 #[inline]
-                pub fn r#optimize_for(&self) -> bool {
+                pub const fn r#optimize_for(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `optimize_for`
                 #[inline]
-                pub fn set_optimize_for(&mut self) -> &mut Self {
+                pub const fn set_optimize_for(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `optimize_for`
                 #[inline]
-                pub fn clear_optimize_for(&mut self) -> &mut Self {
+                pub const fn clear_optimize_for(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `optimize_for`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_optimize_for(mut self) -> Self {
+                pub const fn init_optimize_for(mut self) -> Self {
                     self.set_optimize_for();
                     self
                 }
                 ///Query presence of `go_package`
                 #[inline]
-                pub fn r#go_package(&self) -> bool {
+                pub const fn r#go_package(&self) -> bool {
                     (self.0[0] & 64) != 0
                 }
                 ///Set presence of `go_package`
                 #[inline]
-                pub fn set_go_package(&mut self) -> &mut Self {
+                pub const fn set_go_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 64;
                     self
                 }
                 ///Clear presence of `go_package`
                 #[inline]
-                pub fn clear_go_package(&mut self) -> &mut Self {
+                pub const fn clear_go_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !64;
                     self
                 }
                 ///Builder method that sets the presence of `go_package`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_go_package(mut self) -> Self {
+                pub const fn init_go_package(mut self) -> Self {
                     self.set_go_package();
                     self
                 }
                 ///Query presence of `cc_generic_services`
                 #[inline]
-                pub fn r#cc_generic_services(&self) -> bool {
+                pub const fn r#cc_generic_services(&self) -> bool {
                     (self.0[0] & 128) != 0
                 }
                 ///Set presence of `cc_generic_services`
                 #[inline]
-                pub fn set_cc_generic_services(&mut self) -> &mut Self {
+                pub const fn set_cc_generic_services(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 128;
                     self
                 }
                 ///Clear presence of `cc_generic_services`
                 #[inline]
-                pub fn clear_cc_generic_services(&mut self) -> &mut Self {
+                pub const fn clear_cc_generic_services(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !128;
                     self
                 }
                 ///Builder method that sets the presence of `cc_generic_services`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_cc_generic_services(mut self) -> Self {
+                pub const fn init_cc_generic_services(mut self) -> Self {
                     self.set_cc_generic_services();
                     self
                 }
                 ///Query presence of `java_generic_services`
                 #[inline]
-                pub fn r#java_generic_services(&self) -> bool {
+                pub const fn r#java_generic_services(&self) -> bool {
                     (self.0[1] & 1) != 0
                 }
                 ///Set presence of `java_generic_services`
                 #[inline]
-                pub fn set_java_generic_services(&mut self) -> &mut Self {
+                pub const fn set_java_generic_services(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `java_generic_services`
                 #[inline]
-                pub fn clear_java_generic_services(&mut self) -> &mut Self {
+                pub const fn clear_java_generic_services(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `java_generic_services`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_java_generic_services(mut self) -> Self {
+                pub const fn init_java_generic_services(mut self) -> Self {
                     self.set_java_generic_services();
                     self
                 }
                 ///Query presence of `py_generic_services`
                 #[inline]
-                pub fn r#py_generic_services(&self) -> bool {
+                pub const fn r#py_generic_services(&self) -> bool {
                     (self.0[1] & 2) != 0
                 }
                 ///Set presence of `py_generic_services`
                 #[inline]
-                pub fn set_py_generic_services(&mut self) -> &mut Self {
+                pub const fn set_py_generic_services(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `py_generic_services`
                 #[inline]
-                pub fn clear_py_generic_services(&mut self) -> &mut Self {
+                pub const fn clear_py_generic_services(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `py_generic_services`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_py_generic_services(mut self) -> Self {
+                pub const fn init_py_generic_services(mut self) -> Self {
                     self.set_py_generic_services();
                     self
                 }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[1] & 4) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
                 ///Query presence of `cc_enable_arenas`
                 #[inline]
-                pub fn r#cc_enable_arenas(&self) -> bool {
+                pub const fn r#cc_enable_arenas(&self) -> bool {
                     (self.0[1] & 8) != 0
                 }
                 ///Set presence of `cc_enable_arenas`
                 #[inline]
-                pub fn set_cc_enable_arenas(&mut self) -> &mut Self {
+                pub const fn set_cc_enable_arenas(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `cc_enable_arenas`
                 #[inline]
-                pub fn clear_cc_enable_arenas(&mut self) -> &mut Self {
+                pub const fn clear_cc_enable_arenas(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `cc_enable_arenas`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_cc_enable_arenas(mut self) -> Self {
+                pub const fn init_cc_enable_arenas(mut self) -> Self {
                     self.set_cc_enable_arenas();
                     self
                 }
                 ///Query presence of `objc_class_prefix`
                 #[inline]
-                pub fn r#objc_class_prefix(&self) -> bool {
+                pub const fn r#objc_class_prefix(&self) -> bool {
                     (self.0[1] & 16) != 0
                 }
                 ///Set presence of `objc_class_prefix`
                 #[inline]
-                pub fn set_objc_class_prefix(&mut self) -> &mut Self {
+                pub const fn set_objc_class_prefix(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `objc_class_prefix`
                 #[inline]
-                pub fn clear_objc_class_prefix(&mut self) -> &mut Self {
+                pub const fn clear_objc_class_prefix(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `objc_class_prefix`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_objc_class_prefix(mut self) -> Self {
+                pub const fn init_objc_class_prefix(mut self) -> Self {
                     self.set_objc_class_prefix();
                     self
                 }
                 ///Query presence of `csharp_namespace`
                 #[inline]
-                pub fn r#csharp_namespace(&self) -> bool {
+                pub const fn r#csharp_namespace(&self) -> bool {
                     (self.0[1] & 32) != 0
                 }
                 ///Set presence of `csharp_namespace`
                 #[inline]
-                pub fn set_csharp_namespace(&mut self) -> &mut Self {
+                pub const fn set_csharp_namespace(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `csharp_namespace`
                 #[inline]
-                pub fn clear_csharp_namespace(&mut self) -> &mut Self {
+                pub const fn clear_csharp_namespace(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `csharp_namespace`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_csharp_namespace(mut self) -> Self {
+                pub const fn init_csharp_namespace(mut self) -> Self {
                     self.set_csharp_namespace();
                     self
                 }
                 ///Query presence of `swift_prefix`
                 #[inline]
-                pub fn r#swift_prefix(&self) -> bool {
+                pub const fn r#swift_prefix(&self) -> bool {
                     (self.0[1] & 64) != 0
                 }
                 ///Set presence of `swift_prefix`
                 #[inline]
-                pub fn set_swift_prefix(&mut self) -> &mut Self {
+                pub const fn set_swift_prefix(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 64;
                     self
                 }
                 ///Clear presence of `swift_prefix`
                 #[inline]
-                pub fn clear_swift_prefix(&mut self) -> &mut Self {
+                pub const fn clear_swift_prefix(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !64;
                     self
                 }
                 ///Builder method that sets the presence of `swift_prefix`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_swift_prefix(mut self) -> Self {
+                pub const fn init_swift_prefix(mut self) -> Self {
                     self.set_swift_prefix();
                     self
                 }
                 ///Query presence of `php_class_prefix`
                 #[inline]
-                pub fn r#php_class_prefix(&self) -> bool {
+                pub const fn r#php_class_prefix(&self) -> bool {
                     (self.0[1] & 128) != 0
                 }
                 ///Set presence of `php_class_prefix`
                 #[inline]
-                pub fn set_php_class_prefix(&mut self) -> &mut Self {
+                pub const fn set_php_class_prefix(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 128;
                     self
                 }
                 ///Clear presence of `php_class_prefix`
                 #[inline]
-                pub fn clear_php_class_prefix(&mut self) -> &mut Self {
+                pub const fn clear_php_class_prefix(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !128;
                     self
                 }
                 ///Builder method that sets the presence of `php_class_prefix`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_php_class_prefix(mut self) -> Self {
+                pub const fn init_php_class_prefix(mut self) -> Self {
                     self.set_php_class_prefix();
                     self
                 }
                 ///Query presence of `php_namespace`
                 #[inline]
-                pub fn r#php_namespace(&self) -> bool {
+                pub const fn r#php_namespace(&self) -> bool {
                     (self.0[2] & 1) != 0
                 }
                 ///Set presence of `php_namespace`
                 #[inline]
-                pub fn set_php_namespace(&mut self) -> &mut Self {
+                pub const fn set_php_namespace(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `php_namespace`
                 #[inline]
-                pub fn clear_php_namespace(&mut self) -> &mut Self {
+                pub const fn clear_php_namespace(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `php_namespace`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_php_namespace(mut self) -> Self {
+                pub const fn init_php_namespace(mut self) -> Self {
                     self.set_php_namespace();
                     self
                 }
                 ///Query presence of `php_metadata_namespace`
                 #[inline]
-                pub fn r#php_metadata_namespace(&self) -> bool {
+                pub const fn r#php_metadata_namespace(&self) -> bool {
                     (self.0[2] & 2) != 0
                 }
                 ///Set presence of `php_metadata_namespace`
                 #[inline]
-                pub fn set_php_metadata_namespace(&mut self) -> &mut Self {
+                pub const fn set_php_metadata_namespace(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `php_metadata_namespace`
                 #[inline]
-                pub fn clear_php_metadata_namespace(&mut self) -> &mut Self {
+                pub const fn clear_php_metadata_namespace(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `php_metadata_namespace`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_php_metadata_namespace(mut self) -> Self {
+                pub const fn init_php_metadata_namespace(mut self) -> Self {
                     self.set_php_metadata_namespace();
                     self
                 }
                 ///Query presence of `ruby_package`
                 #[inline]
-                pub fn r#ruby_package(&self) -> bool {
+                pub const fn r#ruby_package(&self) -> bool {
                     (self.0[2] & 4) != 0
                 }
                 ///Set presence of `ruby_package`
                 #[inline]
-                pub fn set_ruby_package(&mut self) -> &mut Self {
+                pub const fn set_ruby_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `ruby_package`
                 #[inline]
-                pub fn clear_ruby_package(&mut self) -> &mut Self {
+                pub const fn clear_ruby_package(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `ruby_package`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_ruby_package(mut self) -> Self {
+                pub const fn init_ruby_package(mut self) -> Self {
                     self.set_ruby_package();
                     self
                 }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[2] & 8) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[2];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
@@ -6359,114 +6431,123 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `message_set_wire_format`
                 #[inline]
-                pub fn r#message_set_wire_format(&self) -> bool {
+                pub const fn r#message_set_wire_format(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `message_set_wire_format`
                 #[inline]
-                pub fn set_message_set_wire_format(&mut self) -> &mut Self {
+                pub const fn set_message_set_wire_format(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `message_set_wire_format`
                 #[inline]
-                pub fn clear_message_set_wire_format(&mut self) -> &mut Self {
+                pub const fn clear_message_set_wire_format(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `message_set_wire_format`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_message_set_wire_format(mut self) -> Self {
+                pub const fn init_message_set_wire_format(mut self) -> Self {
                     self.set_message_set_wire_format();
                     self
                 }
                 ///Query presence of `no_standard_descriptor_accessor`
                 #[inline]
-                pub fn r#no_standard_descriptor_accessor(&self) -> bool {
+                pub const fn r#no_standard_descriptor_accessor(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `no_standard_descriptor_accessor`
                 #[inline]
-                pub fn set_no_standard_descriptor_accessor(&mut self) -> &mut Self {
+                pub const fn set_no_standard_descriptor_accessor(
+                    &mut self,
+                ) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `no_standard_descriptor_accessor`
                 #[inline]
-                pub fn clear_no_standard_descriptor_accessor(&mut self) -> &mut Self {
+                pub const fn clear_no_standard_descriptor_accessor(
+                    &mut self,
+                ) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `no_standard_descriptor_accessor`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_no_standard_descriptor_accessor(mut self) -> Self {
+                pub const fn init_no_standard_descriptor_accessor(mut self) -> Self {
                     self.set_no_standard_descriptor_accessor();
                     self
                 }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
                 ///Query presence of `map_entry`
                 #[inline]
-                pub fn r#map_entry(&self) -> bool {
+                pub const fn r#map_entry(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `map_entry`
                 #[inline]
-                pub fn set_map_entry(&mut self) -> &mut Self {
+                pub const fn set_map_entry(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `map_entry`
                 #[inline]
-                pub fn clear_map_entry(&mut self) -> &mut Self {
+                pub const fn clear_map_entry(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `map_entry`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_map_entry(mut self) -> Self {
+                pub const fn init_map_entry(mut self) -> Self {
                     self.set_map_entry();
                     self
                 }
                 ///Query presence of `deprecated_legacy_json_field_conflicts`
                 #[inline]
-                pub fn r#deprecated_legacy_json_field_conflicts(&self) -> bool {
+                pub const fn r#deprecated_legacy_json_field_conflicts(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `deprecated_legacy_json_field_conflicts`
                 #[inline]
-                pub fn set_deprecated_legacy_json_field_conflicts(
+                pub const fn set_deprecated_legacy_json_field_conflicts(
                     &mut self,
                 ) -> &mut Self {
                     let elem = &mut self.0[0];
@@ -6475,7 +6556,7 @@ pub mod google_ {
                 }
                 ///Clear presence of `deprecated_legacy_json_field_conflicts`
                 #[inline]
-                pub fn clear_deprecated_legacy_json_field_conflicts(
+                pub const fn clear_deprecated_legacy_json_field_conflicts(
                     &mut self,
                 ) -> &mut Self {
                     let elem = &mut self.0[0];
@@ -6484,32 +6565,34 @@ pub mod google_ {
                 }
                 ///Builder method that sets the presence of `deprecated_legacy_json_field_conflicts`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated_legacy_json_field_conflicts(mut self) -> Self {
+                pub const fn init_deprecated_legacy_json_field_conflicts(
+                    mut self,
+                ) -> Self {
                     self.set_deprecated_legacy_json_field_conflicts();
                     self
                 }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
@@ -6903,53 +6986,58 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `edition`
                     #[inline]
-                    pub fn r#edition(&self) -> bool {
+                    pub const fn r#edition(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `edition`
                     #[inline]
-                    pub fn set_edition(&mut self) -> &mut Self {
+                    pub const fn set_edition(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `edition`
                     #[inline]
-                    pub fn clear_edition(&mut self) -> &mut Self {
+                    pub const fn clear_edition(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `edition`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_edition(mut self) -> Self {
+                    pub const fn init_edition(mut self) -> Self {
                         self.set_edition();
                         self
                     }
                     ///Query presence of `value`
                     #[inline]
-                    pub fn r#value(&self) -> bool {
+                    pub const fn r#value(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `value`
                     #[inline]
-                    pub fn set_value(&mut self) -> &mut Self {
+                    pub const fn set_value(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `value`
                     #[inline]
-                    pub fn clear_value(&mut self) -> &mut Self {
+                    pub const fn clear_value(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `value`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_value(mut self) -> Self {
+                    pub const fn init_value(mut self) -> Self {
                         self.set_value();
                         self
                     }
@@ -7100,103 +7188,108 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `edition_introduced`
                     #[inline]
-                    pub fn r#edition_introduced(&self) -> bool {
+                    pub const fn r#edition_introduced(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `edition_introduced`
                     #[inline]
-                    pub fn set_edition_introduced(&mut self) -> &mut Self {
+                    pub const fn set_edition_introduced(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `edition_introduced`
                     #[inline]
-                    pub fn clear_edition_introduced(&mut self) -> &mut Self {
+                    pub const fn clear_edition_introduced(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `edition_introduced`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_edition_introduced(mut self) -> Self {
+                    pub const fn init_edition_introduced(mut self) -> Self {
                         self.set_edition_introduced();
                         self
                     }
                     ///Query presence of `edition_deprecated`
                     #[inline]
-                    pub fn r#edition_deprecated(&self) -> bool {
+                    pub const fn r#edition_deprecated(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `edition_deprecated`
                     #[inline]
-                    pub fn set_edition_deprecated(&mut self) -> &mut Self {
+                    pub const fn set_edition_deprecated(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `edition_deprecated`
                     #[inline]
-                    pub fn clear_edition_deprecated(&mut self) -> &mut Self {
+                    pub const fn clear_edition_deprecated(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `edition_deprecated`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_edition_deprecated(mut self) -> Self {
+                    pub const fn init_edition_deprecated(mut self) -> Self {
                         self.set_edition_deprecated();
                         self
                     }
                     ///Query presence of `deprecation_warning`
                     #[inline]
-                    pub fn r#deprecation_warning(&self) -> bool {
+                    pub const fn r#deprecation_warning(&self) -> bool {
                         (self.0[0] & 4) != 0
                     }
                     ///Set presence of `deprecation_warning`
                     #[inline]
-                    pub fn set_deprecation_warning(&mut self) -> &mut Self {
+                    pub const fn set_deprecation_warning(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 4;
                         self
                     }
                     ///Clear presence of `deprecation_warning`
                     #[inline]
-                    pub fn clear_deprecation_warning(&mut self) -> &mut Self {
+                    pub const fn clear_deprecation_warning(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !4;
                         self
                     }
                     ///Builder method that sets the presence of `deprecation_warning`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_deprecation_warning(mut self) -> Self {
+                    pub const fn init_deprecation_warning(mut self) -> Self {
                         self.set_deprecation_warning();
                         self
                     }
                     ///Query presence of `edition_removed`
                     #[inline]
-                    pub fn r#edition_removed(&self) -> bool {
+                    pub const fn r#edition_removed(&self) -> bool {
                         (self.0[0] & 8) != 0
                     }
                     ///Set presence of `edition_removed`
                     #[inline]
-                    pub fn set_edition_removed(&mut self) -> &mut Self {
+                    pub const fn set_edition_removed(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 8;
                         self
                     }
                     ///Clear presence of `edition_removed`
                     #[inline]
-                    pub fn clear_edition_removed(&mut self) -> &mut Self {
+                    pub const fn clear_edition_removed(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !8;
                         self
                     }
                     ///Builder method that sets the presence of `edition_removed`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_edition_removed(mut self) -> Self {
+                    pub const fn init_edition_removed(mut self) -> Self {
                         self.set_edition_removed();
                         self
                     }
@@ -7570,278 +7663,283 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 2]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 2])
+                }
                 ///Query presence of `ctype`
                 #[inline]
-                pub fn r#ctype(&self) -> bool {
+                pub const fn r#ctype(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `ctype`
                 #[inline]
-                pub fn set_ctype(&mut self) -> &mut Self {
+                pub const fn set_ctype(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `ctype`
                 #[inline]
-                pub fn clear_ctype(&mut self) -> &mut Self {
+                pub const fn clear_ctype(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `ctype`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_ctype(mut self) -> Self {
+                pub const fn init_ctype(mut self) -> Self {
                     self.set_ctype();
                     self
                 }
                 ///Query presence of `packed`
                 #[inline]
-                pub fn r#packed(&self) -> bool {
+                pub const fn r#packed(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `packed`
                 #[inline]
-                pub fn set_packed(&mut self) -> &mut Self {
+                pub const fn set_packed(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `packed`
                 #[inline]
-                pub fn clear_packed(&mut self) -> &mut Self {
+                pub const fn clear_packed(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `packed`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_packed(mut self) -> Self {
+                pub const fn init_packed(mut self) -> Self {
                     self.set_packed();
                     self
                 }
                 ///Query presence of `jstype`
                 #[inline]
-                pub fn r#jstype(&self) -> bool {
+                pub const fn r#jstype(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `jstype`
                 #[inline]
-                pub fn set_jstype(&mut self) -> &mut Self {
+                pub const fn set_jstype(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `jstype`
                 #[inline]
-                pub fn clear_jstype(&mut self) -> &mut Self {
+                pub const fn clear_jstype(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `jstype`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_jstype(mut self) -> Self {
+                pub const fn init_jstype(mut self) -> Self {
                     self.set_jstype();
                     self
                 }
                 ///Query presence of `lazy`
                 #[inline]
-                pub fn r#lazy(&self) -> bool {
+                pub const fn r#lazy(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `lazy`
                 #[inline]
-                pub fn set_lazy(&mut self) -> &mut Self {
+                pub const fn set_lazy(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `lazy`
                 #[inline]
-                pub fn clear_lazy(&mut self) -> &mut Self {
+                pub const fn clear_lazy(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `lazy`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_lazy(mut self) -> Self {
+                pub const fn init_lazy(mut self) -> Self {
                     self.set_lazy();
                     self
                 }
                 ///Query presence of `unverified_lazy`
                 #[inline]
-                pub fn r#unverified_lazy(&self) -> bool {
+                pub const fn r#unverified_lazy(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `unverified_lazy`
                 #[inline]
-                pub fn set_unverified_lazy(&mut self) -> &mut Self {
+                pub const fn set_unverified_lazy(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `unverified_lazy`
                 #[inline]
-                pub fn clear_unverified_lazy(&mut self) -> &mut Self {
+                pub const fn clear_unverified_lazy(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `unverified_lazy`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_unverified_lazy(mut self) -> Self {
+                pub const fn init_unverified_lazy(mut self) -> Self {
                     self.set_unverified_lazy();
                     self
                 }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
                 ///Query presence of `weak`
                 #[inline]
-                pub fn r#weak(&self) -> bool {
+                pub const fn r#weak(&self) -> bool {
                     (self.0[0] & 64) != 0
                 }
                 ///Set presence of `weak`
                 #[inline]
-                pub fn set_weak(&mut self) -> &mut Self {
+                pub const fn set_weak(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 64;
                     self
                 }
                 ///Clear presence of `weak`
                 #[inline]
-                pub fn clear_weak(&mut self) -> &mut Self {
+                pub const fn clear_weak(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !64;
                     self
                 }
                 ///Builder method that sets the presence of `weak`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_weak(mut self) -> Self {
+                pub const fn init_weak(mut self) -> Self {
                     self.set_weak();
                     self
                 }
                 ///Query presence of `debug_redact`
                 #[inline]
-                pub fn r#debug_redact(&self) -> bool {
+                pub const fn r#debug_redact(&self) -> bool {
                     (self.0[0] & 128) != 0
                 }
                 ///Set presence of `debug_redact`
                 #[inline]
-                pub fn set_debug_redact(&mut self) -> &mut Self {
+                pub const fn set_debug_redact(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 128;
                     self
                 }
                 ///Clear presence of `debug_redact`
                 #[inline]
-                pub fn clear_debug_redact(&mut self) -> &mut Self {
+                pub const fn clear_debug_redact(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !128;
                     self
                 }
                 ///Builder method that sets the presence of `debug_redact`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_debug_redact(mut self) -> Self {
+                pub const fn init_debug_redact(mut self) -> Self {
                     self.set_debug_redact();
                     self
                 }
                 ///Query presence of `retention`
                 #[inline]
-                pub fn r#retention(&self) -> bool {
+                pub const fn r#retention(&self) -> bool {
                     (self.0[1] & 1) != 0
                 }
                 ///Set presence of `retention`
                 #[inline]
-                pub fn set_retention(&mut self) -> &mut Self {
+                pub const fn set_retention(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `retention`
                 #[inline]
-                pub fn clear_retention(&mut self) -> &mut Self {
+                pub const fn clear_retention(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `retention`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_retention(mut self) -> Self {
+                pub const fn init_retention(mut self) -> Self {
                     self.set_retention();
                     self
                 }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[1] & 2) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
                 ///Query presence of `feature_support`
                 #[inline]
-                pub fn r#feature_support(&self) -> bool {
+                pub const fn r#feature_support(&self) -> bool {
                     (self.0[1] & 4) != 0
                 }
                 ///Set presence of `feature_support`
                 #[inline]
-                pub fn set_feature_support(&mut self) -> &mut Self {
+                pub const fn set_feature_support(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `feature_support`
                 #[inline]
-                pub fn clear_feature_support(&mut self) -> &mut Self {
+                pub const fn clear_feature_support(&mut self) -> &mut Self {
                     let elem = &mut self.0[1];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `feature_support`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_feature_support(mut self) -> Self {
+                pub const fn init_feature_support(mut self) -> Self {
                     self.set_feature_support();
                     self
                 }
@@ -8518,28 +8616,33 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
@@ -8645,64 +8748,69 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `allow_alias`
                 #[inline]
-                pub fn r#allow_alias(&self) -> bool {
+                pub const fn r#allow_alias(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `allow_alias`
                 #[inline]
-                pub fn set_allow_alias(&mut self) -> &mut Self {
+                pub const fn set_allow_alias(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `allow_alias`
                 #[inline]
-                pub fn clear_allow_alias(&mut self) -> &mut Self {
+                pub const fn clear_allow_alias(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `allow_alias`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_allow_alias(mut self) -> Self {
+                pub const fn init_allow_alias(mut self) -> Self {
                     self.set_allow_alias();
                     self
                 }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
                 ///Query presence of `deprecated_legacy_json_field_conflicts`
                 #[inline]
-                pub fn r#deprecated_legacy_json_field_conflicts(&self) -> bool {
+                pub const fn r#deprecated_legacy_json_field_conflicts(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `deprecated_legacy_json_field_conflicts`
                 #[inline]
-                pub fn set_deprecated_legacy_json_field_conflicts(
+                pub const fn set_deprecated_legacy_json_field_conflicts(
                     &mut self,
                 ) -> &mut Self {
                     let elem = &mut self.0[0];
@@ -8711,7 +8819,7 @@ pub mod google_ {
                 }
                 ///Clear presence of `deprecated_legacy_json_field_conflicts`
                 #[inline]
-                pub fn clear_deprecated_legacy_json_field_conflicts(
+                pub const fn clear_deprecated_legacy_json_field_conflicts(
                     &mut self,
                 ) -> &mut Self {
                     let elem = &mut self.0[0];
@@ -8720,32 +8828,34 @@ pub mod google_ {
                 }
                 ///Builder method that sets the presence of `deprecated_legacy_json_field_conflicts`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated_legacy_json_field_conflicts(mut self) -> Self {
+                pub const fn init_deprecated_legacy_json_field_conflicts(
+                    mut self,
+                ) -> Self {
                     self.set_deprecated_legacy_json_field_conflicts();
                     self
                 }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
@@ -9017,103 +9127,108 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
                 ///Query presence of `debug_redact`
                 #[inline]
-                pub fn r#debug_redact(&self) -> bool {
+                pub const fn r#debug_redact(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `debug_redact`
                 #[inline]
-                pub fn set_debug_redact(&mut self) -> &mut Self {
+                pub const fn set_debug_redact(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `debug_redact`
                 #[inline]
-                pub fn clear_debug_redact(&mut self) -> &mut Self {
+                pub const fn clear_debug_redact(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `debug_redact`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_debug_redact(mut self) -> Self {
+                pub const fn init_debug_redact(mut self) -> Self {
                     self.set_debug_redact();
                     self
                 }
                 ///Query presence of `feature_support`
                 #[inline]
-                pub fn r#feature_support(&self) -> bool {
+                pub const fn r#feature_support(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `feature_support`
                 #[inline]
-                pub fn set_feature_support(&mut self) -> &mut Self {
+                pub const fn set_feature_support(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `feature_support`
                 #[inline]
-                pub fn clear_feature_support(&mut self) -> &mut Self {
+                pub const fn clear_feature_support(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `feature_support`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_feature_support(mut self) -> Self {
+                pub const fn init_feature_support(mut self) -> Self {
                     self.set_feature_support();
                     self
                 }
@@ -9377,53 +9492,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
@@ -9596,78 +9716,83 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `deprecated`
                 #[inline]
-                pub fn r#deprecated(&self) -> bool {
+                pub const fn r#deprecated(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `deprecated`
                 #[inline]
-                pub fn set_deprecated(&mut self) -> &mut Self {
+                pub const fn set_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `deprecated`
                 #[inline]
-                pub fn clear_deprecated(&mut self) -> &mut Self {
+                pub const fn clear_deprecated(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `deprecated`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_deprecated(mut self) -> Self {
+                pub const fn init_deprecated(mut self) -> Self {
                     self.set_deprecated();
                     self
                 }
                 ///Query presence of `idempotency_level`
                 #[inline]
-                pub fn r#idempotency_level(&self) -> bool {
+                pub const fn r#idempotency_level(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `idempotency_level`
                 #[inline]
-                pub fn set_idempotency_level(&mut self) -> &mut Self {
+                pub const fn set_idempotency_level(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `idempotency_level`
                 #[inline]
-                pub fn clear_idempotency_level(&mut self) -> &mut Self {
+                pub const fn clear_idempotency_level(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `idempotency_level`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_idempotency_level(mut self) -> Self {
+                pub const fn init_idempotency_level(mut self) -> Self {
                     self.set_idempotency_level();
                     self
                 }
                 ///Query presence of `features`
                 #[inline]
-                pub fn r#features(&self) -> bool {
+                pub const fn r#features(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `features`
                 #[inline]
-                pub fn set_features(&mut self) -> &mut Self {
+                pub const fn set_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `features`
                 #[inline]
-                pub fn clear_features(&mut self) -> &mut Self {
+                pub const fn clear_features(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `features`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_features(mut self) -> Self {
+                pub const fn init_features(mut self) -> Self {
                     self.set_features();
                     self
                 }
@@ -9886,53 +10011,58 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `name_part`
                     #[inline]
-                    pub fn r#name_part(&self) -> bool {
+                    pub const fn r#name_part(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `name_part`
                     #[inline]
-                    pub fn set_name_part(&mut self) -> &mut Self {
+                    pub const fn set_name_part(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `name_part`
                     #[inline]
-                    pub fn clear_name_part(&mut self) -> &mut Self {
+                    pub const fn clear_name_part(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `name_part`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_name_part(mut self) -> Self {
+                    pub const fn init_name_part(mut self) -> Self {
                         self.set_name_part();
                         self
                     }
                     ///Query presence of `is_extension`
                     #[inline]
-                    pub fn r#is_extension(&self) -> bool {
+                    pub const fn r#is_extension(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `is_extension`
                     #[inline]
-                    pub fn set_is_extension(&mut self) -> &mut Self {
+                    pub const fn set_is_extension(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `is_extension`
                     #[inline]
-                    pub fn clear_is_extension(&mut self) -> &mut Self {
+                    pub const fn clear_is_extension(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `is_extension`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_is_extension(mut self) -> Self {
+                    pub const fn init_is_extension(mut self) -> Self {
                         self.set_is_extension();
                         self
                     }
@@ -10081,153 +10211,158 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `identifier_value`
                 #[inline]
-                pub fn r#identifier_value(&self) -> bool {
+                pub const fn r#identifier_value(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `identifier_value`
                 #[inline]
-                pub fn set_identifier_value(&mut self) -> &mut Self {
+                pub const fn set_identifier_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `identifier_value`
                 #[inline]
-                pub fn clear_identifier_value(&mut self) -> &mut Self {
+                pub const fn clear_identifier_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `identifier_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_identifier_value(mut self) -> Self {
+                pub const fn init_identifier_value(mut self) -> Self {
                     self.set_identifier_value();
                     self
                 }
                 ///Query presence of `positive_int_value`
                 #[inline]
-                pub fn r#positive_int_value(&self) -> bool {
+                pub const fn r#positive_int_value(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `positive_int_value`
                 #[inline]
-                pub fn set_positive_int_value(&mut self) -> &mut Self {
+                pub const fn set_positive_int_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `positive_int_value`
                 #[inline]
-                pub fn clear_positive_int_value(&mut self) -> &mut Self {
+                pub const fn clear_positive_int_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `positive_int_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_positive_int_value(mut self) -> Self {
+                pub const fn init_positive_int_value(mut self) -> Self {
                     self.set_positive_int_value();
                     self
                 }
                 ///Query presence of `negative_int_value`
                 #[inline]
-                pub fn r#negative_int_value(&self) -> bool {
+                pub const fn r#negative_int_value(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `negative_int_value`
                 #[inline]
-                pub fn set_negative_int_value(&mut self) -> &mut Self {
+                pub const fn set_negative_int_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `negative_int_value`
                 #[inline]
-                pub fn clear_negative_int_value(&mut self) -> &mut Self {
+                pub const fn clear_negative_int_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `negative_int_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_negative_int_value(mut self) -> Self {
+                pub const fn init_negative_int_value(mut self) -> Self {
                     self.set_negative_int_value();
                     self
                 }
                 ///Query presence of `double_value`
                 #[inline]
-                pub fn r#double_value(&self) -> bool {
+                pub const fn r#double_value(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `double_value`
                 #[inline]
-                pub fn set_double_value(&mut self) -> &mut Self {
+                pub const fn set_double_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `double_value`
                 #[inline]
-                pub fn clear_double_value(&mut self) -> &mut Self {
+                pub const fn clear_double_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `double_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_double_value(mut self) -> Self {
+                pub const fn init_double_value(mut self) -> Self {
                     self.set_double_value();
                     self
                 }
                 ///Query presence of `string_value`
                 #[inline]
-                pub fn r#string_value(&self) -> bool {
+                pub const fn r#string_value(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `string_value`
                 #[inline]
-                pub fn set_string_value(&mut self) -> &mut Self {
+                pub const fn set_string_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `string_value`
                 #[inline]
-                pub fn clear_string_value(&mut self) -> &mut Self {
+                pub const fn clear_string_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `string_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_string_value(mut self) -> Self {
+                pub const fn init_string_value(mut self) -> Self {
                     self.set_string_value();
                     self
                 }
                 ///Query presence of `aggregate_value`
                 #[inline]
-                pub fn r#aggregate_value(&self) -> bool {
+                pub const fn r#aggregate_value(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `aggregate_value`
                 #[inline]
-                pub fn set_aggregate_value(&mut self) -> &mut Self {
+                pub const fn set_aggregate_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `aggregate_value`
                 #[inline]
-                pub fn clear_aggregate_value(&mut self) -> &mut Self {
+                pub const fn clear_aggregate_value(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `aggregate_value`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_aggregate_value(mut self) -> Self {
+                pub const fn init_aggregate_value(mut self) -> Self {
                     self.set_aggregate_value();
                     self
                 }
@@ -10723,153 +10858,158 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `field_presence`
                 #[inline]
-                pub fn r#field_presence(&self) -> bool {
+                pub const fn r#field_presence(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `field_presence`
                 #[inline]
-                pub fn set_field_presence(&mut self) -> &mut Self {
+                pub const fn set_field_presence(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `field_presence`
                 #[inline]
-                pub fn clear_field_presence(&mut self) -> &mut Self {
+                pub const fn clear_field_presence(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `field_presence`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_field_presence(mut self) -> Self {
+                pub const fn init_field_presence(mut self) -> Self {
                     self.set_field_presence();
                     self
                 }
                 ///Query presence of `enum_type`
                 #[inline]
-                pub fn r#enum_type(&self) -> bool {
+                pub const fn r#enum_type(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `enum_type`
                 #[inline]
-                pub fn set_enum_type(&mut self) -> &mut Self {
+                pub const fn set_enum_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `enum_type`
                 #[inline]
-                pub fn clear_enum_type(&mut self) -> &mut Self {
+                pub const fn clear_enum_type(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `enum_type`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_enum_type(mut self) -> Self {
+                pub const fn init_enum_type(mut self) -> Self {
                     self.set_enum_type();
                     self
                 }
                 ///Query presence of `repeated_field_encoding`
                 #[inline]
-                pub fn r#repeated_field_encoding(&self) -> bool {
+                pub const fn r#repeated_field_encoding(&self) -> bool {
                     (self.0[0] & 4) != 0
                 }
                 ///Set presence of `repeated_field_encoding`
                 #[inline]
-                pub fn set_repeated_field_encoding(&mut self) -> &mut Self {
+                pub const fn set_repeated_field_encoding(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 4;
                     self
                 }
                 ///Clear presence of `repeated_field_encoding`
                 #[inline]
-                pub fn clear_repeated_field_encoding(&mut self) -> &mut Self {
+                pub const fn clear_repeated_field_encoding(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !4;
                     self
                 }
                 ///Builder method that sets the presence of `repeated_field_encoding`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_repeated_field_encoding(mut self) -> Self {
+                pub const fn init_repeated_field_encoding(mut self) -> Self {
                     self.set_repeated_field_encoding();
                     self
                 }
                 ///Query presence of `utf8_validation`
                 #[inline]
-                pub fn r#utf8_validation(&self) -> bool {
+                pub const fn r#utf8_validation(&self) -> bool {
                     (self.0[0] & 8) != 0
                 }
                 ///Set presence of `utf8_validation`
                 #[inline]
-                pub fn set_utf8_validation(&mut self) -> &mut Self {
+                pub const fn set_utf8_validation(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 8;
                     self
                 }
                 ///Clear presence of `utf8_validation`
                 #[inline]
-                pub fn clear_utf8_validation(&mut self) -> &mut Self {
+                pub const fn clear_utf8_validation(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !8;
                     self
                 }
                 ///Builder method that sets the presence of `utf8_validation`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_utf8_validation(mut self) -> Self {
+                pub const fn init_utf8_validation(mut self) -> Self {
                     self.set_utf8_validation();
                     self
                 }
                 ///Query presence of `message_encoding`
                 #[inline]
-                pub fn r#message_encoding(&self) -> bool {
+                pub const fn r#message_encoding(&self) -> bool {
                     (self.0[0] & 16) != 0
                 }
                 ///Set presence of `message_encoding`
                 #[inline]
-                pub fn set_message_encoding(&mut self) -> &mut Self {
+                pub const fn set_message_encoding(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 16;
                     self
                 }
                 ///Clear presence of `message_encoding`
                 #[inline]
-                pub fn clear_message_encoding(&mut self) -> &mut Self {
+                pub const fn clear_message_encoding(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !16;
                     self
                 }
                 ///Builder method that sets the presence of `message_encoding`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_message_encoding(mut self) -> Self {
+                pub const fn init_message_encoding(mut self) -> Self {
                     self.set_message_encoding();
                     self
                 }
                 ///Query presence of `json_format`
                 #[inline]
-                pub fn r#json_format(&self) -> bool {
+                pub const fn r#json_format(&self) -> bool {
                     (self.0[0] & 32) != 0
                 }
                 ///Set presence of `json_format`
                 #[inline]
-                pub fn set_json_format(&mut self) -> &mut Self {
+                pub const fn set_json_format(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 32;
                     self
                 }
                 ///Clear presence of `json_format`
                 #[inline]
-                pub fn clear_json_format(&mut self) -> &mut Self {
+                pub const fn clear_json_format(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !32;
                     self
                 }
                 ///Builder method that sets the presence of `json_format`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_json_format(mut self) -> Self {
+                pub const fn init_json_format(mut self) -> Self {
                     self.set_json_format();
                     self
                 }
@@ -11284,78 +11424,83 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `edition`
                     #[inline]
-                    pub fn r#edition(&self) -> bool {
+                    pub const fn r#edition(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `edition`
                     #[inline]
-                    pub fn set_edition(&mut self) -> &mut Self {
+                    pub const fn set_edition(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `edition`
                     #[inline]
-                    pub fn clear_edition(&mut self) -> &mut Self {
+                    pub const fn clear_edition(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `edition`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_edition(mut self) -> Self {
+                    pub const fn init_edition(mut self) -> Self {
                         self.set_edition();
                         self
                     }
                     ///Query presence of `overridable_features`
                     #[inline]
-                    pub fn r#overridable_features(&self) -> bool {
+                    pub const fn r#overridable_features(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `overridable_features`
                     #[inline]
-                    pub fn set_overridable_features(&mut self) -> &mut Self {
+                    pub const fn set_overridable_features(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `overridable_features`
                     #[inline]
-                    pub fn clear_overridable_features(&mut self) -> &mut Self {
+                    pub const fn clear_overridable_features(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `overridable_features`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_overridable_features(mut self) -> Self {
+                    pub const fn init_overridable_features(mut self) -> Self {
                         self.set_overridable_features();
                         self
                     }
                     ///Query presence of `fixed_features`
                     #[inline]
-                    pub fn r#fixed_features(&self) -> bool {
+                    pub const fn r#fixed_features(&self) -> bool {
                         (self.0[0] & 4) != 0
                     }
                     ///Set presence of `fixed_features`
                     #[inline]
-                    pub fn set_fixed_features(&mut self) -> &mut Self {
+                    pub const fn set_fixed_features(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 4;
                         self
                     }
                     ///Clear presence of `fixed_features`
                     #[inline]
-                    pub fn clear_fixed_features(&mut self) -> &mut Self {
+                    pub const fn clear_fixed_features(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !4;
                         self
                     }
                     ///Builder method that sets the presence of `fixed_features`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_fixed_features(mut self) -> Self {
+                    pub const fn init_fixed_features(mut self) -> Self {
                         self.set_fixed_features();
                         self
                     }
@@ -11573,53 +11718,58 @@ pub mod google_ {
             #[derive(Debug, Default, PartialEq, Clone)]
             pub struct _Hazzer([u8; 1]);
             impl _Hazzer {
+                ///New hazzer with all fields set to off
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; 1])
+                }
                 ///Query presence of `minimum_edition`
                 #[inline]
-                pub fn r#minimum_edition(&self) -> bool {
+                pub const fn r#minimum_edition(&self) -> bool {
                     (self.0[0] & 1) != 0
                 }
                 ///Set presence of `minimum_edition`
                 #[inline]
-                pub fn set_minimum_edition(&mut self) -> &mut Self {
+                pub const fn set_minimum_edition(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 1;
                     self
                 }
                 ///Clear presence of `minimum_edition`
                 #[inline]
-                pub fn clear_minimum_edition(&mut self) -> &mut Self {
+                pub const fn clear_minimum_edition(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !1;
                     self
                 }
                 ///Builder method that sets the presence of `minimum_edition`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_minimum_edition(mut self) -> Self {
+                pub const fn init_minimum_edition(mut self) -> Self {
                     self.set_minimum_edition();
                     self
                 }
                 ///Query presence of `maximum_edition`
                 #[inline]
-                pub fn r#maximum_edition(&self) -> bool {
+                pub const fn r#maximum_edition(&self) -> bool {
                     (self.0[0] & 2) != 0
                 }
                 ///Set presence of `maximum_edition`
                 #[inline]
-                pub fn set_maximum_edition(&mut self) -> &mut Self {
+                pub const fn set_maximum_edition(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem |= 2;
                     self
                 }
                 ///Clear presence of `maximum_edition`
                 #[inline]
-                pub fn clear_maximum_edition(&mut self) -> &mut Self {
+                pub const fn clear_maximum_edition(&mut self) -> &mut Self {
                     let elem = &mut self.0[0];
                     *elem &= !2;
                     self
                 }
                 ///Builder method that sets the presence of `maximum_edition`. Useful for initializing the Hazzer.
                 #[inline]
-                pub fn init_maximum_edition(mut self) -> Self {
+                pub const fn init_maximum_edition(mut self) -> Self {
                     self.set_maximum_edition();
                     self
                 }
@@ -11782,53 +11932,58 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `leading_comments`
                     #[inline]
-                    pub fn r#leading_comments(&self) -> bool {
+                    pub const fn r#leading_comments(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `leading_comments`
                     #[inline]
-                    pub fn set_leading_comments(&mut self) -> &mut Self {
+                    pub const fn set_leading_comments(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `leading_comments`
                     #[inline]
-                    pub fn clear_leading_comments(&mut self) -> &mut Self {
+                    pub const fn clear_leading_comments(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `leading_comments`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_leading_comments(mut self) -> Self {
+                    pub const fn init_leading_comments(mut self) -> Self {
                         self.set_leading_comments();
                         self
                     }
                     ///Query presence of `trailing_comments`
                     #[inline]
-                    pub fn r#trailing_comments(&self) -> bool {
+                    pub const fn r#trailing_comments(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `trailing_comments`
                     #[inline]
-                    pub fn set_trailing_comments(&mut self) -> &mut Self {
+                    pub const fn set_trailing_comments(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `trailing_comments`
                     #[inline]
-                    pub fn clear_trailing_comments(&mut self) -> &mut Self {
+                    pub const fn clear_trailing_comments(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `trailing_comments`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_trailing_comments(mut self) -> Self {
+                    pub const fn init_trailing_comments(mut self) -> Self {
                         self.set_trailing_comments();
                         self
                     }
@@ -12114,103 +12269,108 @@ pub mod google_ {
                 #[derive(Debug, Default, PartialEq, Clone)]
                 pub struct _Hazzer([u8; 1]);
                 impl _Hazzer {
+                    ///New hazzer with all fields set to off
+                    #[inline]
+                    pub const fn _new() -> Self {
+                        Self([0; 1])
+                    }
                     ///Query presence of `source_file`
                     #[inline]
-                    pub fn r#source_file(&self) -> bool {
+                    pub const fn r#source_file(&self) -> bool {
                         (self.0[0] & 1) != 0
                     }
                     ///Set presence of `source_file`
                     #[inline]
-                    pub fn set_source_file(&mut self) -> &mut Self {
+                    pub const fn set_source_file(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 1;
                         self
                     }
                     ///Clear presence of `source_file`
                     #[inline]
-                    pub fn clear_source_file(&mut self) -> &mut Self {
+                    pub const fn clear_source_file(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !1;
                         self
                     }
                     ///Builder method that sets the presence of `source_file`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_source_file(mut self) -> Self {
+                    pub const fn init_source_file(mut self) -> Self {
                         self.set_source_file();
                         self
                     }
                     ///Query presence of `begin`
                     #[inline]
-                    pub fn r#begin(&self) -> bool {
+                    pub const fn r#begin(&self) -> bool {
                         (self.0[0] & 2) != 0
                     }
                     ///Set presence of `begin`
                     #[inline]
-                    pub fn set_begin(&mut self) -> &mut Self {
+                    pub const fn set_begin(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 2;
                         self
                     }
                     ///Clear presence of `begin`
                     #[inline]
-                    pub fn clear_begin(&mut self) -> &mut Self {
+                    pub const fn clear_begin(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !2;
                         self
                     }
                     ///Builder method that sets the presence of `begin`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_begin(mut self) -> Self {
+                    pub const fn init_begin(mut self) -> Self {
                         self.set_begin();
                         self
                     }
                     ///Query presence of `end`
                     #[inline]
-                    pub fn r#end(&self) -> bool {
+                    pub const fn r#end(&self) -> bool {
                         (self.0[0] & 4) != 0
                     }
                     ///Set presence of `end`
                     #[inline]
-                    pub fn set_end(&mut self) -> &mut Self {
+                    pub const fn set_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 4;
                         self
                     }
                     ///Clear presence of `end`
                     #[inline]
-                    pub fn clear_end(&mut self) -> &mut Self {
+                    pub const fn clear_end(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !4;
                         self
                     }
                     ///Builder method that sets the presence of `end`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_end(mut self) -> Self {
+                    pub const fn init_end(mut self) -> Self {
                         self.set_end();
                         self
                     }
                     ///Query presence of `semantic`
                     #[inline]
-                    pub fn r#semantic(&self) -> bool {
+                    pub const fn r#semantic(&self) -> bool {
                         (self.0[0] & 8) != 0
                     }
                     ///Set presence of `semantic`
                     #[inline]
-                    pub fn set_semantic(&mut self) -> &mut Self {
+                    pub const fn set_semantic(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem |= 8;
                         self
                     }
                     ///Clear presence of `semantic`
                     #[inline]
-                    pub fn clear_semantic(&mut self) -> &mut Self {
+                    pub const fn clear_semantic(&mut self) -> &mut Self {
                         let elem = &mut self.0[0];
                         *elem &= !8;
                         self
                     }
                     ///Builder method that sets the presence of `semantic`. Useful for initializing the Hazzer.
                     #[inline]
-                    pub fn init_semantic(mut self) -> Self {
+                    pub const fn init_semantic(mut self) -> Self {
                         self.set_semantic();
                         self
                     }

--- a/micropb-gen/src/generator.rs
+++ b/micropb-gen/src/generator.rs
@@ -3,6 +3,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     ffi::OsString,
+    fmt::Display,
     io,
     path::PathBuf,
 };
@@ -92,12 +93,12 @@ fn generate_mod_tree(mod_node: &mut Node<TokenStream>) -> TokenStream {
     }
 }
 
-fn field_error(pkg: &str, msg_name: &str, field_name: &str, err_text: &str) -> io::Error {
+fn field_error(pkg: &str, msg_name: &str, field_name: &str, err_text: impl Display) -> io::Error {
     let dot = if pkg.is_empty() { "" } else { "." };
     io::Error::other(format!("({dot}{pkg}.{msg_name}.{field_name}) {err_text}"))
 }
 
-fn msg_error(pkg: &str, msg_name: &str, err_text: &str) -> io::Error {
+fn msg_error(pkg: &str, msg_name: &str, err_text: impl Display) -> io::Error {
     let dot = if pkg.is_empty() { "" } else { "." };
     io::Error::other(format!("({dot}{pkg}.{msg_name}) {err_text}"))
 }

--- a/micropb-gen/src/generator/field.rs
+++ b/micropb-gen/src/generator/field.rs
@@ -591,7 +591,7 @@ impl<'a> Field<'a> {
                     }
                 };
                 quote! {
-                    for (k, v) in self.#fname.pb_iter() {
+                    for (k, v) in (&#extra_deref self.#fname).into_iter() {
                         let len = ::micropb::size::sizeof_map_elem(k, v, |#val_ref| { #key_sizeof }, |#val_ref| { #val_sizeof });
                         #stmts
                     }

--- a/micropb-gen/src/generator/field.rs
+++ b/micropb-gen/src/generator/field.rs
@@ -36,7 +36,7 @@ pub(crate) enum FieldType {
     Repeated {
         typ: TypeSpec,
         packed: bool,
-        type_path: syn::Path,
+        type_path: syn::Type,
         max_len: Option<u32>,
     },
     Custom(CustomField),
@@ -77,7 +77,7 @@ impl<'a> Field<'a> {
     pub(crate) fn from_proto(
         proto: &'a FieldDescriptorProto,
         field_conf: &CurrentConfig,
-        syntax: Syntax,
+        gen: &Generator,
         map_msg: Option<&DescriptorProto>,
     ) -> Result<Option<Self>, String> {
         if field_conf.config.skip.unwrap_or(false) {
@@ -99,31 +99,42 @@ impl<'a> Field<'a> {
             (None, Some(map_msg), _) => {
                 let key = TypeSpec::from_proto(&map_msg.field[0], &field_conf.next_conf("key"))?;
                 let val = TypeSpec::from_proto(&map_msg.field[1], &field_conf.next_conf("value"))?;
-                let type_path = field_conf.config.map_type_parsed()?.ok_or_else(|| {
-                    "Field is of type `map`, but map_type was not configured for it".to_owned()
-                })?;
+                let max_len = field_conf.config.max_len;
+                let type_path = field_conf
+                    .config
+                    .map_type_parsed(
+                        key.generate_rust_type(gen),
+                        val.generate_rust_type(gen),
+                        max_len,
+                    )?
+                    .ok_or_else(|| "map_type not configured for map field".to_owned())?;
                 FieldType::Map {
                     key,
                     val,
                     type_path,
-                    max_len: field_conf.config.max_len,
+                    max_len,
                 }
             }
 
-            (None, None, Label::Repeated) => FieldType::Repeated {
-                typ: TypeSpec::from_proto(proto, &field_conf.next_conf("elem"))?,
-                type_path: field_conf.config.vec_type_parsed()?.ok_or_else(|| {
-                    "Field is repeated, but vec_type was not configured for it".to_owned()
-                })?,
-                max_len: field_conf.config.max_len,
-                packed: proto
-                    .options()
-                    .and_then(|opt| opt.packed().copied())
-                    .unwrap_or(false),
-            },
+            (None, None, Label::Repeated) => {
+                let typ = TypeSpec::from_proto(proto, &field_conf.next_conf("elem"))?;
+                let max_len = field_conf.config.max_len;
+                FieldType::Repeated {
+                    type_path: field_conf
+                        .config
+                        .vec_type_parsed(typ.generate_rust_type(gen), max_len)?
+                        .ok_or_else(|| "vec_type not configured for repeated field".to_owned())?,
+                    typ,
+                    max_len,
+                    packed: proto
+                        .options()
+                        .and_then(|opt| opt.packed().copied())
+                        .unwrap_or(false),
+                }
+            }
 
             (None, None, Label::Required | Label::Optional)
-                if syntax == Syntax::Proto2
+                if gen.syntax == Syntax::Proto2
                     || proto.proto3_optional
                     || proto.r#type == Type::Message =>
             {
@@ -155,31 +166,9 @@ impl<'a> Field<'a> {
 
     pub(crate) fn generate_rust_type(&self, gen: &Generator) -> TokenStream {
         let typ = match &self.ftype {
-            FieldType::Map {
-                key,
-                val,
-                type_path: type_name,
-                max_len,
-                ..
-            } => {
-                let k = key.generate_rust_type(gen);
-                let v = val.generate_rust_type(gen);
-                let max_len = max_len.map(Literal::u32_unsuffixed).into_iter();
-                quote! { #type_name <#k, #v #(, #max_len)* > }
-            }
-
+            FieldType::Map { type_path, .. } => quote! { #type_path },
             FieldType::Single(t) | FieldType::Optional(t, _) => t.generate_rust_type(gen),
-
-            FieldType::Repeated {
-                typ,
-                type_path,
-                max_len,
-                ..
-            } => {
-                let t = typ.generate_rust_type(gen);
-                let max_len = max_len.map(Literal::u32_unsuffixed).into_iter();
-                quote! { #type_path <#t #(, #max_len)* > }
-            }
+            FieldType::Repeated { type_path, .. } => quote! { #type_path },
 
             FieldType::Custom(CustomField::Type(t)) => return quote! {#t},
             FieldType::Custom(CustomField::Delegate(_)) => {
@@ -750,7 +739,10 @@ mod tests {
             config: Cow::Borrowed(&config),
         };
         let field = field_proto(2, "field", None, false);
-        assert!(Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+
+        let mut gen = Generator::new();
+        gen.syntax = Syntax::Proto2;
+        assert!(Field::from_proto(&field, &field_conf, &gen, None)
             .unwrap()
             .is_none());
     }
@@ -763,8 +755,11 @@ mod tests {
             config: Cow::Borrowed(&config),
         };
         let field = field_proto(2, "field", None, false);
+
+        let mut gen = Generator::new();
+        gen.syntax = Syntax::Proto3;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto3, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap(),
             Field {
@@ -793,8 +788,9 @@ mod tests {
         };
         let mut field = field_proto(2, "field", None, false);
         field.set_default_value("true".to_owned());
+
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto3, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap(),
             Field {
@@ -819,15 +815,19 @@ mod tests {
             config: Cow::Borrowed(&config),
         };
         let field = field_proto(0, "field", None, false);
+
+        let mut gen = Generator::new();
+        gen.syntax = Syntax::Proto3;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto3, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
             FieldType::Single(TypeSpec::Bool)
         );
+        gen.syntax = Syntax::Proto2;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -837,7 +837,7 @@ mod tests {
         // Required fields are treated like optionals
         let field = field_proto(0, "field", Some(Label::Required), false);
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -845,9 +845,10 @@ mod tests {
         );
 
         // In proto3, if proto3_optional is set then field is optional
+        gen.syntax = Syntax::Proto3;
         let field = field_proto(0, "field", Some(Label::Optional), true);
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto3, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -860,8 +861,9 @@ mod tests {
             node: None,
             config: Cow::Borrowed(&config),
         };
+        gen.syntax = Syntax::Proto2;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -875,7 +877,7 @@ mod tests {
             config: Cow::Borrowed(&config),
         };
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -897,8 +899,11 @@ mod tests {
             config: Cow::Borrowed(&config),
         };
         let field = field_proto(1, "field", Some(Label::Optional), true);
+
+        let mut gen = Generator::new();
+        gen.syntax = Syntax::Proto2;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -916,7 +921,7 @@ mod tests {
         };
         let field = field_proto(1, "field", Some(Label::Optional), true);
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -938,8 +943,11 @@ mod tests {
 
         let mut field = field_proto(0, "field", Some(Label::Repeated), false);
         field.set_type(Type::Int32);
+
+        let mut gen = Generator::new();
+        gen.syntax = Syntax::Proto3;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto3, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -953,7 +961,7 @@ mod tests {
         field.set_options(Default::default());
         field.options.set_packed(true);
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto3, None)
+            Field::from_proto(&field, &field_conf, &gen, None)
                 .unwrap()
                 .unwrap()
                 .ftype,
@@ -1004,8 +1012,10 @@ mod tests {
         field.set_type(Type::Message);
         field.set_type_name("MapElem".to_owned());
 
+        let mut gen = Generator::new();
+        gen.syntax = Syntax::Proto2;
         assert_eq!(
-            Field::from_proto(&field, &field_conf, Syntax::Proto2, Some(&map_elem))
+            Field::from_proto(&field, &field_conf, &gen, Some(&map_elem))
                 .unwrap()
                 .unwrap()
                 .ftype,

--- a/micropb-gen/src/generator/field.rs
+++ b/micropb-gen/src/generator/field.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Literal, Span, TokenStream};
+use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Ident, Lifetime};
 

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -117,7 +117,7 @@ impl<'a> Message<'a> {
         }
 
         // Remove all oneofs that are empty enums or synthetic oneofs
-        let oneofs: Vec<_> = oneofs
+        let mut oneofs: Vec<_> = oneofs
             .into_iter()
             .filter(|o| !matches!(&o.otype, OneofType::Enum { fields, .. } if fields.is_empty()))
             .filter(|o| !synthetic_oneof_idx.contains(&o.idx))
@@ -136,7 +136,7 @@ impl<'a> Message<'a> {
         let lifetime = fields
             .iter()
             .find_map(|f| f.find_lifetime())
-            .or_else(|| oneofs.iter().find_map(|o| o.find_lifetime()))
+            .or_else(|| oneofs.iter_mut().find_map(|o| o.find_lifetime()))
             .or_else(|| unknown_handler.as_ref().and_then(find_lifetime_from_type))
             .cloned();
 
@@ -744,6 +744,7 @@ mod tests {
                     derive_dbg: false,
                     derive_partial_eq: true,
                     derive_clone: true,
+                    lifetime: None,
                     idx: 0
                 }],
                 fields: vec![

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -411,7 +411,7 @@ impl<'a> Message<'a> {
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>>
                 {
-                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
+                    use ::micropb::{PbBytes, PbString, PbVec, PbMap, FieldDecode};
 
                     let before = #decoder.bytes_read();
                     while #decoder.bytes_read() - before < len {

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -185,13 +185,13 @@ impl<'a> Message<'a> {
             quote! {
                 #[doc = #getter_doc]
                 #[inline]
-                pub fn #fname(&self) -> bool {
+                pub const fn #fname(&self) -> bool {
                     (self.0[#idx] & #mask) != 0
                 }
 
                 #[doc = #setter_doc]
                 #[inline]
-                pub fn #setter(&mut self) -> &mut Self {
+                pub const fn #setter(&mut self) -> &mut Self {
                     let elem = &mut self.0[#idx];
                     *elem |= #mask;
                     self
@@ -199,7 +199,7 @@ impl<'a> Message<'a> {
 
                 #[doc = #clearer_doc]
                 #[inline]
-                pub fn #clearer(&mut self) -> &mut Self {
+                pub const fn #clearer(&mut self) -> &mut Self {
                     let elem = &mut self.0[#idx];
                     *elem &= !#mask;
                     self
@@ -207,7 +207,7 @@ impl<'a> Message<'a> {
 
                 #[doc = #init_doc]
                 #[inline]
-                pub fn #init(mut self) -> Self {
+                pub const fn #init(mut self) -> Self {
                     self.#setter();
                     self
                 }
@@ -221,6 +221,12 @@ impl<'a> Message<'a> {
             pub struct #hazzer_name([u8; #bytes]);
 
             impl #hazzer_name {
+                #[doc = "New hazzer with all fields set to off"]
+                #[inline]
+                pub const fn _new() -> Self {
+                    Self([0; #bytes])
+                }
+
                 #(#methods)*
             }
         };

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -411,7 +411,7 @@ impl<'a> Message<'a> {
                     len: usize,
                 ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>>
                 {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldDecode};
+                    use ::micropb::{PbBytes, PbVec, PbMap, FieldDecode};
 
                     let before = #decoder.bytes_read();
                     while #decoder.bytes_read() - before < len {
@@ -505,13 +505,13 @@ impl<'a> Message<'a> {
                     encoder: &mut ::micropb::PbEncoder<IMPL_MICROPB_WRITE>,
                 ) -> Result<(), IMPL_MICROPB_WRITE::Error>
                 {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldEncode};
+                    use ::micropb::{PbMap, FieldEncode};
                     #encode
                     Ok(())
                 }
 
                 fn compute_size(&self) -> usize {
-                    use ::micropb::{PbVec, PbMap, PbString, FieldEncode};
+                    use ::micropb::{PbMap, FieldEncode};
                     let mut size = 0;
                     #sizeof
                     size

--- a/micropb-gen/src/generator/message.rs
+++ b/micropb-gen/src/generator/message.rs
@@ -77,7 +77,7 @@ impl<'a> Message<'a> {
                 .map(|(_, r)| r)
                 .unwrap_or(&f.type_name);
             let field = if let Some(map_msg) = map_types.remove(raw_msg_name) {
-                Field::from_proto(f, &field_conf, gen.syntax, Some(map_msg))
+                Field::from_proto(f, &field_conf, gen, Some(map_msg))
                     .map_err(|e| field_error(&gen.pkg, msg_name, &f.name, &e))?
             } else {
                 if let Some(idx) = f.oneof_index().copied() {
@@ -108,7 +108,7 @@ impl<'a> Message<'a> {
                     }
                 }
                 // Normal field
-                Field::from_proto(f, &field_conf, gen.syntax, None)
+                Field::from_proto(f, &field_conf, gen, None)
                     .map_err(|e| field_error(&gen.pkg, msg_name, &f.name, &e))?
             };
             if let Some(field) = field {

--- a/micropb-gen/src/generator/type_spec.rs
+++ b/micropb-gen/src/generator/type_spec.rs
@@ -157,6 +157,16 @@ pub(crate) enum TypeSpec {
 }
 
 impl TypeSpec {
+    pub(crate) fn find_lifetime(&self) -> Option<&Lifetime> {
+        match self {
+            TypeSpec::Message(_, lifetime) => lifetime.as_ref(),
+            TypeSpec::Bytes { type_path, .. } | TypeSpec::String { type_path, .. } => {
+                find_lifetime_from_type(type_path)
+            }
+            _ => None,
+        }
+    }
+
     fn max_size(&self) -> Option<usize> {
         match self {
             TypeSpec::Float | TypeSpec::Int(PbInt::Fixed32 | PbInt::Sfixed32, _) => Some(4),

--- a/micropb-gen/src/generator/type_spec.rs
+++ b/micropb-gen/src/generator/type_spec.rs
@@ -283,7 +283,7 @@ impl TypeSpec {
                 match *max_bytes {
                     Some(max_bytes) if bytes.len() > max_bytes as usize =>
                         return Err(format!("Bytes field is limited to {max_bytes} bytes, but its default value is {} bytes", bytes.len())),
-                    _ => quote! { ::core::convert::TryFrom::try_from(#default_bytes).unwrap_or_default() }
+                    _ => quote! { ::core::convert::TryFrom::try_from(#default_bytes.as_slice()).unwrap_or_default() }
                 }
             }
 
@@ -769,7 +769,7 @@ mod tests {
             .generate_default("abc\\n\\t\\a\\xA0ddd", &gen)
             .unwrap()
             .to_string(),
-            quote! { ::core::convert::TryFrom::try_from(b"abc\n\t\x07\xA0ddd").unwrap_or_default() }
+            quote! { ::core::convert::TryFrom::try_from(b"abc\n\t\x07\xA0ddd".as_slice()).unwrap_or_default() }
                 .to_string()
         );
     }

--- a/micropb-gen/src/generator/type_spec.rs
+++ b/micropb-gen/src/generator/type_spec.rs
@@ -146,12 +146,13 @@ pub(crate) enum TypeSpec {
     Double,
     Bool,
     Int(PbInt, IntSize),
+    // Box the syn::Type fields since they're taking up too much space
     String {
-        type_path: syn::Type,
+        type_path: Box<syn::Type>,
         max_bytes: Option<u32>,
     },
     Bytes {
-        type_path: syn::Type,
+        type_path: Box<syn::Type>,
         max_bytes: Option<u32>,
     },
 }
@@ -214,15 +215,17 @@ impl TypeSpec {
             Type::Float => TypeSpec::Float,
             Type::Bool => TypeSpec::Bool,
             Type::String => TypeSpec::String {
-                type_path: conf
-                    .string_type_parsed(conf.max_bytes)?
-                    .ok_or_else(|| "string_type not configured for string field".to_owned())?,
+                type_path: Box::new(
+                    conf.string_type_parsed(conf.max_bytes)?
+                        .ok_or_else(|| "string_type not configured for string field".to_owned())?,
+                ),
                 max_bytes: conf.max_bytes,
             },
             Type::Bytes => TypeSpec::Bytes {
-                type_path: conf
-                    .bytes_type_parsed(conf.max_bytes)?
-                    .ok_or_else(|| "bytes_type not configured for bytes field".to_owned())?,
+                type_path: Box::new(
+                    conf.bytes_type_parsed(conf.max_bytes)?
+                        .ok_or_else(|| "bytes_type not configured for bytes field".to_owned())?,
+                ),
                 max_bytes: conf.max_bytes,
             },
             Type::Message => {

--- a/micropb-gen/src/generator/type_spec.rs
+++ b/micropb-gen/src/generator/type_spec.rs
@@ -285,7 +285,7 @@ impl TypeSpec {
                 match *max_bytes {
                     Some(max_bytes) if default.len() > max_bytes as usize =>
                         return Err(format!("String field is limited to {max_bytes} bytes, but its default value is {} bytes", default.len())),
-                    _ => quote! { ::micropb::PbString::pb_from_str(#default).unwrap_or_default() }
+                    _ => quote! { ::core::convert::TryFrom::try_from(#default).unwrap_or_default() }
                 }
             }
 
@@ -295,7 +295,7 @@ impl TypeSpec {
                 match *max_bytes {
                     Some(max_bytes) if bytes.len() > max_bytes as usize =>
                         return Err(format!("Bytes field is limited to {max_bytes} bytes, but its default value is {} bytes", bytes.len())),
-                    _ => quote! { ::micropb::PbVec::pb_from_slice(#default_bytes).unwrap_or_default() }
+                    _ => quote! { ::core::convert::TryFrom::try_from(#default_bytes.as_slice()).unwrap_or_default() }
                 }
             }
 
@@ -768,7 +768,7 @@ mod tests {
             .generate_default("abc\n\tddd", &gen)
             .unwrap()
             .to_string(),
-            quote! { ::micropb::PbString::pb_from_str("abc\n\tddd").unwrap_or_default() }
+            quote! { ::core::convert::TryFrom::try_from("abc\n\tddd".as_slice()).unwrap_or_default() }
                 .to_string()
         );
         assert_eq!(
@@ -779,7 +779,7 @@ mod tests {
             .generate_default("abc\\n\\t\\a\\xA0ddd", &gen)
             .unwrap()
             .to_string(),
-            quote! { ::micropb::PbVec::pb_from_slice(b"abc\n\t\x07\xA0ddd").unwrap_or_default() }
+            quote! { ::core::convert::TryFrom::try_from(b"abc\n\t\x07\xA0ddd").unwrap_or_default() }
                 .to_string()
         );
     }

--- a/micropb-gen/src/lib.rs
+++ b/micropb-gen/src/lib.rs
@@ -172,10 +172,10 @@ impl Generator {
     ///
     /// If using this option, `micropb` should have the `container-heapless` feature enabled.
     ///
-    /// Specifically, `heapless::String` is generated for `string` fields, `heapless::Vec` is
-    /// generated for `bytes` and repeated fields, and `heapless::FnvIndexMap` is generated for
-    /// `map` fields. This uses [`configure`](Self::configure) under the hood, so configurations
-    /// set by this call can all be overriden by future configurations.
+    /// Specifically, `heapless::String<N>` is generated for `string` fields, `heapless::Vec<u8, N>`
+    /// for `bytes` fields, `heapless::Vec<T, N>` for repeated fields, and
+    /// `heapless::FnvIndexMap<K, V, N>` for `map` fields. This uses [`configure`](Self::configure)
+    /// under the hood, so configurations set by this call can all be overriden.
     ///
     /// # Note
     /// Since `heapless` containers are fixed size, [`max_len`](Config::max_len) or
@@ -184,9 +184,10 @@ impl Generator {
         self.configure(
             ".",
             Config::new()
-                .vec_type("::micropb::heapless::Vec")
-                .string_type("::micropb::heapless::String")
-                .map_type("::micropb::heapless::FnvIndexMap"),
+                .vec_type("::micropb::heapless::Vec<$T, $N>")
+                .string_type("::micropb::heapless::String<$N>")
+                .bytes_type("::micropb::heapless::Vec<u8, $N>")
+                .map_type("::micropb::heapless::FnvIndexMap<$K, $V, $N>"),
         );
         self
     }
@@ -196,15 +197,15 @@ impl Generator {
     ///
     /// If using this option, `micropb` should have the `container-arrayvec` feature enabled.
     ///
-    /// Specifically, `arrayvec::ArrayString` is generated for `string` fields, and
-    /// `arrayvec::ArrayVec` is generated for `bytes` and repeated fields. This uses
-    /// [`configure`](Self::configure) under the hood, so configurations set by this call can all
-    /// be overriden by future configurations.
+    /// Specifically, `arrayvec::ArrayString<N>` is generated for `string` fields,
+    /// `arrayvec::ArrayVec<u8, N>` for `bytes` fields, and `arrayvec::ArrayVec<T, N>` for repeated
+    /// fields. This uses [`configure`](Self::configure) under the hood, so configurations set by
+    /// this call can all be overriden.
     ///
     /// # Note
     /// No container is configured for `map` fields, since `arrayvec` doesn't have a suitable map
-    /// type. If the .proto files contain `map` fields, [`map_type`](Config::map_type) needs to be
-    /// configured separately.
+    /// type. If the .proto files contain `map` fields, [`map_type`](Config::map_type) will need to
+    /// be configured separately.
     ///
     /// Since `arrayvec` containers are fixed size, [`max_len`](Config::max_len) or
     /// [`max_bytes`](Config::max_bytes) must be set for all fields that generate these containers.
@@ -212,8 +213,9 @@ impl Generator {
         self.configure(
             ".",
             Config::new()
-                .vec_type("::micropb::arrayvec::ArrayVec")
-                .string_type("::micropb::arrayvec::ArrayString"),
+                .vec_type("::micropb::arrayvec::ArrayVec<$T, $N>")
+                .bytes_type("::micropb::arrayvec::ArrayVec<u8, $N>")
+                .string_type("::micropb::arrayvec::ArrayString<$N>"),
         );
         self
     }
@@ -223,22 +225,19 @@ impl Generator {
     ///
     /// If using this option, `micropb` should have the `alloc` feature enabled.
     ///
-    /// Specifically, `alloc::string::String` is generated for `string` fields, `alloc::vec::Vec`
-    /// is generated for `bytes` and repeated fields, and `alloc::collections::BTreeMap` is
-    /// generated for `map` fields. This uses [`configure`](Self::configure) under the hood, so
-    /// configurations set by this call can all be overriden by future configurations.
-    ///
-    /// # Note
-    /// Since `alloc` containers are dynamic size, [`max_len`](Config::max_bytes) and
-    /// [`max_bytes`](Config::max_bytes) must NOT be set for all fields that generate these
-    /// containers.
+    /// Specifically, `alloc::string::String` is generated for `string` fields,
+    /// `alloc::vec::Vec<u8>` is for `bytes` fields, `alloc::vec::Vec<T>` for repeated fields, and
+    /// `alloc::collections::BTreeMap<K, V>` for `map` fields. This uses
+    /// [`configure`](Self::configure) under the hood, so configurations set by this call can all
+    /// be overriden by future configurations.
     pub fn use_container_alloc(&mut self) -> &mut Self {
         self.configure(
             ".",
             Config::new()
-                .vec_type("::alloc::vec::Vec")
+                .vec_type("::alloc::vec::Vec<$T>")
+                .bytes_type("::alloc::vec::Vec::<u8>")
                 .string_type("::alloc::string::String")
-                .map_type("::alloc::collections::BTreeMap"),
+                .map_type("::alloc::collections::BTreeMap<$K, $V>"),
         );
         self
     }
@@ -248,22 +247,19 @@ impl Generator {
     ///
     /// If using this option, `micropb` should have the `std` feature enabled.
     ///
-    /// Specifically, `std::string::String` is generated for `string` fields, `std::vec::Vec`
-    /// is generated for `bytes` and repeated fields, and `std::collections::HashMap` is
-    /// generated for `map` fields. This uses [`configure`](Self::configure) under the hood, so
-    /// configurations set by this call can all be overriden by future configurations.
-    ///
-    /// # Note
-    /// Since `std` containers are dynamic size, [`max_len`](Config::max_bytes) and
-    /// [`max_bytes`](Config::max_bytes) must NOT be set for all fields that generate these
-    /// containers.
+    /// Specifically, `std::string::String` is generated for `string` fields, `std::vec::Vec<u8>`
+    /// for `bytes` fields, `std::vec::Vec<T>` for repeated fields, and
+    /// `std::collections::HashMap<K, V>` for `map` fields. This uses
+    /// [`configure`](Self::configure) under the hood, so configurations set by this call can all
+    /// be overriden by future configurations.
     pub fn use_container_std(&mut self) -> &mut Self {
         self.configure(
             ".",
             Config::new()
-                .vec_type("::std::vec::Vec")
+                .vec_type("::std::vec::Vec<$T>")
+                .bytes_type("::std::vec::Vec::<u8>")
                 .string_type("::std::string::String")
-                .map_type("::std::collections::HashMap"),
+                .map_type("::std::collections::HashMap<$K, $V>"),
         );
         self
     }

--- a/micropb/README.md
+++ b/micropb/README.md
@@ -211,9 +211,10 @@ gen.use_container_alloc();
 /*
 gen.configure(".",
     micropb_gen::Config::new()
-        .string_type("crate::MyString")
-        .vec_type("crate::MyVec")
-        .map_type("crate::MyMap")
+        .string_type("crate::MyString<$N>")
+        .bytes_type("crate::MyVec<u8, $N>")
+        .vec_type("crate::MyVec<$T, $N>")
+        .map_type("crate::MyMap<$K, $V, $N>")
 );
 */
 
@@ -232,7 +233,9 @@ pub struct Containers {
 }
 ```
 
-A container type is expected to implement `PbVec`, `PbString`, or `PbMap` from `micropb::container`, depending on what type of field it's used for. For convenience, `micropb` comes with built-in implementations of the container traits for types from [`heapless`](https://docs.rs/heapless/latest/heapless), [`arrayvec`](https://docs.rs/arrayvec/latest/arrayvec), and [`alloc`](https://doc.rust-lang.org/alloc) (see [Feature Flags](#feature-flags) for details).
+A container type is expected to implement `PbVec`, `PbString`, `PbBytes`, or `PbMap` from `micropb::container`, depending on what type of field it's used for. For convenience, `micropb` comes with built-in implementations of the container traits for types from [`heapless`](https://docs.rs/heapless/latest/heapless), [`arrayvec`](https://docs.rs/arrayvec/latest/arrayvec), and [`alloc`](https://doc.rust-lang.org/alloc) (see [Feature Flags](#feature-flags) for details).
+
+However, if only encoding logic is required, then the container traits are unnecessary. In that case, the only requirement for container types is that they dereference into `&[T]`, `&str`, and `&[u8]`, depending on what type of field it's for.
 
 ### Optional Fields
 

--- a/micropb/src/container.rs
+++ b/micropb/src/container.rs
@@ -215,6 +215,14 @@ pub(crate) mod impl_fixed_len {
             value.0
         }
     }
+
+    impl<T: Copy, const N: usize> TryFrom<&[T]> for FixedLenArray<T, N> {
+        type Error = TryFromSliceError;
+
+        fn try_from(value: &[T]) -> Result<Self, Self::Error> {
+            Ok(Self(value.try_into()?))
+        }
+    }
 }
 
 #[cfg(feature = "container-arrayvec")]

--- a/micropb/src/container.rs
+++ b/micropb/src/container.rs
@@ -45,10 +45,10 @@ pub trait PbString {
     /// Returns the remaining spare capacity of the string as a slice of `MaybeUninit<u8>`.
     ///
     /// The returned slice can be filled with bytes before marking the data as initialized using
-    /// [`pb_set_len`](PbContainer::pb_set_len).
+    /// [`pb_set_len`](PbString::pb_set_len).
     ///
     /// # Safety
-    /// When calling [`pb_set_len`](PbContainer::pb_set_len) after filling the spare capacity with
+    /// When calling [`pb_set_len`](PbString::pb_set_len) after filling the spare capacity with
     /// bytes, the entirety of the new string must be valid UTF-8.
     fn pb_spare_cap(&mut self) -> &mut [MaybeUninit<u8>];
 }

--- a/micropb/src/container.rs
+++ b/micropb/src/container.rs
@@ -457,7 +457,7 @@ mod impl_alloc {
 
     impl<T> PbVec<T> for Cow<'_, [T]>
     where
-        [T]: ToOwned<Owned = Vec<T>>,
+        [T]: alloc::borrow::ToOwned<Owned = Vec<T>>,
     {
         fn pb_push(&mut self, elem: T) -> Result<(), ()> {
             self.to_mut().push(elem);

--- a/micropb/src/decode.rs
+++ b/micropb/src/decode.rs
@@ -1472,7 +1472,7 @@ mod tests {
             }
             #[test]
             fn proptest_fixedarray(data in bytes_strat(4..32)) {
-                check_bytes([u8; 16], data);
+                check_bytes([0u8; 16], data);
             }
         }
     }

--- a/micropb/src/decode.rs
+++ b/micropb/src/decode.rs
@@ -1171,7 +1171,7 @@ mod tests {
     container_test!(string, string_heapless, heapless::String::<4>, true, false);
     container_test!(string, string_alloc, String, false, false);
     container_test!(string, string_fixed_len, FixedLenString::<4>, true, true);
-    container_test!(string, string_cow, Cow::<'static, str>, true, true);
+    container_test!(string, string_cow, Cow::<'static, str>, false, false);
 
     fn bytes<S: PbBytes + AsRef<[u8]> + Default>(fixed_cap: bool, fixed_len: bool) {
         let mut bytes = S::default();
@@ -1220,7 +1220,7 @@ mod tests {
     container_test!(bytes, bytes_heapless, heapless::Vec::<_, 3>, true, false);
     container_test!(bytes, bytes_alloc, Vec<_>, false, false);
     container_test!(bytes, bytes_fixed, [u8; 3], true, true);
-    container_test!(bytes, bytes_cow, Cow::<'static, [u8]>, true, true);
+    container_test!(bytes, bytes_cow, Cow::<'static, [u8]>, false, false);
 
     fn packed<S: PbVec<u32> + AsRef<[u32]> + Default>(fixed_cap: bool, _fixed_len: bool) {
         let mut vec1 = S::default();
@@ -1261,7 +1261,7 @@ mod tests {
     container_test!(packed, packed_arrayvec, ArrayVec::<_, 5>, true, false);
     container_test!(packed, packed_heapless, heapless::Vec::<_, 5>, true, false);
     container_test!(packed, packed_alloc, Vec<_>, false, false);
-    container_test!(packed, packed_cow, Cow::<'static, [_]>, true, true);
+    container_test!(packed, packed_cow, Cow::<'static, [_]>, false, false);
 
     //#[cfg(target_endian = "little")]
     //fn packed_fixed<S: PbVec<u32>>(fixed_cap: bool) {

--- a/micropb/src/decode.rs
+++ b/micropb/src/decode.rs
@@ -1472,7 +1472,7 @@ mod tests {
             }
             #[test]
             fn proptest_fixedarray(data in bytes_strat(4..32)) {
-                check_bytes(FixedLenArray::<u8, 16>::default(), data);
+                check_bytes([u8; 16], data);
             }
         }
     }

--- a/micropb/src/decode.rs
+++ b/micropb/src/decode.rs
@@ -702,6 +702,8 @@ impl<R: PbRead> PbDecoder<R> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use arrayvec::{ArrayString, ArrayVec};
 
     use crate::FixedLenString;
@@ -1169,6 +1171,7 @@ mod tests {
     container_test!(string, string_heapless, heapless::String::<4>, true, false);
     container_test!(string, string_alloc, String, false, false);
     container_test!(string, string_fixed_len, FixedLenString::<4>, true, true);
+    container_test!(string, string_cow, Cow::<'static, str>, true, true);
 
     fn bytes<S: PbBytes + AsRef<[u8]> + Default>(fixed_cap: bool, fixed_len: bool) {
         let mut bytes = S::default();
@@ -1217,6 +1220,7 @@ mod tests {
     container_test!(bytes, bytes_heapless, heapless::Vec::<_, 3>, true, false);
     container_test!(bytes, bytes_alloc, Vec<_>, false, false);
     container_test!(bytes, bytes_fixed, [u8; 3], true, true);
+    container_test!(bytes, bytes_cow, Cow::<'static, [u8]>, true, true);
 
     fn packed<S: PbVec<u32> + AsRef<[u32]> + Default>(fixed_cap: bool, _fixed_len: bool) {
         let mut vec1 = S::default();
@@ -1257,6 +1261,7 @@ mod tests {
     container_test!(packed, packed_arrayvec, ArrayVec::<_, 5>, true, false);
     container_test!(packed, packed_heapless, heapless::Vec::<_, 5>, true, false);
     container_test!(packed, packed_alloc, Vec<_>, false, false);
+    container_test!(packed, packed_cow, Cow::<'static, [_]>, true, true);
 
     //#[cfg(target_endian = "little")]
     //fn packed_fixed<S: PbVec<u32>>(fixed_cap: bool) {
@@ -1457,6 +1462,10 @@ mod tests {
             fn proptest_fixedstring(data in bytes_strat(4..32)) {
                 check_string(FixedLenString::<16>::default(), data);
             }
+            #[test]
+            fn proptest_cowstr(data in bytes_strat(4..32)) {
+                check_string(Cow::<str>::from(""), data);
+            }
 
             #[test]
             fn proptest_vec(data in bytes_strat(4..32)) {
@@ -1473,6 +1482,10 @@ mod tests {
             #[test]
             fn proptest_fixedarray(data in bytes_strat(4..32)) {
                 check_bytes([0u8; 16], data);
+            }
+            #[test]
+            fn proptest_cowarray(data in bytes_strat(4..32)) {
+                check_bytes(Cow::<[u8]>::from(b""), data);
             }
         }
     }

--- a/micropb/src/lib.rs
+++ b/micropb/src/lib.rs
@@ -24,7 +24,7 @@ pub use ::arrayvec;
 pub use ::heapless;
 pub use container::impl_fixed_len::{FixedLenArray, FixedLenString};
 
-pub use container::{PbContainer, PbMap, PbString, PbVec};
+pub use container::{PbBytes, PbMap, PbVec};
 #[cfg(feature = "decode")]
 pub use decode::{DecodeError, PbDecoder, PbRead};
 #[cfg(feature = "encode")]

--- a/micropb/src/lib.rs
+++ b/micropb/src/lib.rs
@@ -22,9 +22,9 @@ pub mod size;
 pub use ::arrayvec;
 #[cfg(feature = "container-heapless")]
 pub use ::heapless;
-pub use container::impl_fixed_len::{FixedLenArray, FixedLenString};
+pub use container::impl_fixed_len::FixedLenString;
 
-pub use container::{PbBytes, PbMap, PbVec};
+pub use container::{PbBytes, PbMap, PbString, PbVec};
 #[cfg(feature = "decode")]
 pub use decode::{DecodeError, PbDecoder, PbRead};
 #[cfg(feature = "encode")]

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -197,6 +197,26 @@ fn container_alloc() {
         .unwrap();
 }
 
+fn container_cow() {
+    let mut generator = Generator::new();
+    generator
+        .configure(
+            ".",
+            Config::new()
+                .string_type("::alloc::borrow::Cow<'a, str>")
+                .vec_type("::alloc::borrow::Cow<'a, [$T]>")
+                .bytes_type("::alloc::borrow::Cow<'a, [u8]>"),
+        )
+        .configure(".List.list", Config::new().field_lifetime("'a"));
+
+    generator
+        .compile_protos(
+            &["proto/collections.proto"],
+            std::env::var("OUT_DIR").unwrap() + "/container_cow.rs",
+        )
+        .unwrap();
+}
+
 fn fixed_string_and_bytes() {
     let mut generator = Generator::new();
     generator.use_container_alloc();
@@ -411,6 +431,7 @@ fn main() {
     container_heapless();
     container_arrayvec();
     container_alloc();
+    container_cow();
     custom_field();
     implicit_presence();
     extern_import();

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -203,13 +203,13 @@ fn fixed_string_and_bytes() {
     generator.configure(
         ".Data.s",
         Config::new()
-            .string_type("::micropb::FixedLenString")
+            .string_type("::micropb::FixedLenString<$N>")
             .max_bytes(3),
     );
     generator.configure(
         ".Data.b",
         Config::new()
-            .vec_type("::micropb::FixedLenArray")
+            .bytes_type("::micropb::FixedLenArray<u8, $N>")
             .max_bytes(2),
     );
 

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -295,20 +295,17 @@ fn lifetime_fields() {
     let mut generator = Generator::new();
     generator.encode_decode(EncodeDecode::EncodeOnly);
     generator.configure(".", Config::new().no_debug_impl(true).no_default_impl(true));
-    generator.configure(
-        ".nested.Nested.inner",
-        Config::new().custom_field(CustomField::Type(
-            "crate::lifetime_fields::RefField<'a>".to_owned(),
-        )),
-    );
-    generator.configure(
-        ".nested.Nested.basic",
-        Config::new().custom_field(CustomField::Delegate("inner".to_owned())),
-    );
+    // InnerMsg has a lifetime param
     generator.configure(
         ".nested.Nested.InnerMsg",
         Config::new().unknown_handler("Option<crate::lifetime_fields::RefField<'a>>"),
     );
+    // So the inner_msg field must have a lifetime
+    generator.configure(
+        ".nested.Nested.inner_msg",
+        Config::new().field_lifetime("'a"),
+    );
+    generator.configure(".nested.Nested.basic", Config::new().skip(true));
     generator.configure(
         ".basic.BasicTypes.int32_num",
         Config::new().custom_field(CustomField::Type(

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -206,12 +206,7 @@ fn fixed_string_and_bytes() {
             .string_type("::micropb::FixedLenString<$N>")
             .max_bytes(3),
     );
-    generator.configure(
-        ".Data.b",
-        Config::new()
-            .bytes_type("::micropb::FixedLenArray<u8, $N>")
-            .max_bytes(2),
-    );
+    generator.configure(".Data.b", Config::new().bytes_type("[u8; $N]").max_bytes(2));
 
     generator
         .compile_protos(

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -306,15 +306,25 @@ fn lifetime_fields() {
         Config::new().field_lifetime("'a"),
     );
     generator.configure(".nested.Nested.basic", Config::new().skip(true));
-    generator.configure(
-        ".basic.BasicTypes.int32_num",
-        Config::new().custom_field(CustomField::Type(
-            "crate::lifetime_fields::RefField<'a>".to_owned(),
-        )),
-    );
+
+    // Configurations for collections.proto
+    generator
+        .configure(
+            ".",
+            Config::new()
+                .string_type("&'a str")
+                .bytes_type("&'a [u8]")
+                .vec_type("&'a [$T]"),
+        )
+        .configure(".List.list", Config::new().field_lifetime("'a"));
+
     generator
         .compile_protos(
-            &["proto/basic.proto", "proto/nested.proto"],
+            &[
+                "proto/basic.proto",
+                "proto/nested.proto",
+                "proto/collections.proto",
+            ],
             std::env::var("OUT_DIR").unwrap() + "/lifetime_fields.rs",
         )
         .unwrap();

--- a/tests/basic-proto/build.rs
+++ b/tests/basic-proto/build.rs
@@ -314,7 +314,8 @@ fn lifetime_fields() {
             Config::new()
                 .string_type("&'a str")
                 .bytes_type("&'a [u8]")
-                .vec_type("&'a [$T]"),
+                .vec_type("&'a [$T]")
+                .map_type("&'a std::collections::HashMap<$K, $V>"),
         )
         .configure(".List.list", Config::new().field_lifetime("'a"));
 
@@ -324,6 +325,7 @@ fn lifetime_fields() {
                 "proto/basic.proto",
                 "proto/nested.proto",
                 "proto/collections.proto",
+                "proto/map.proto",
             ],
             std::env::var("OUT_DIR").unwrap() + "/lifetime_fields.rs",
         )

--- a/tests/basic-proto/src/container_cow.rs
+++ b/tests/basic-proto/src/container_cow.rs
@@ -1,0 +1,31 @@
+use std::borrow::Cow;
+
+mod proto {
+    #![allow(clippy::all)]
+    #![allow(nonstandard_style, unused, irrefutable_let_patterns)]
+    include!(concat!(env!("OUT_DIR"), "/container_cow.rs"));
+}
+
+#[test]
+fn string_bytes() {
+    let data = proto::Data::default();
+    assert!(data.s().is_none());
+    assert!(data.b().is_none());
+    assert_eq!(data.s, "a\n\0");
+    assert_eq!(data.b.as_ref(), &[0x0, 0xFF]);
+    let _: Cow<str> = data.s;
+    let _: Cow<[u8]> = data.b;
+}
+
+#[test]
+fn repeated() {
+    let list = proto::List::default();
+    assert!(list.list.is_empty());
+    assert_eq!(size_of_val(&list), size_of::<Vec<proto::Data>>());
+    let _: Cow<[proto::Data<'_>]> = list.list;
+
+    let numlist = proto::NumList::default();
+    assert!(numlist.list.is_empty());
+    assert_eq!(size_of_val(&numlist), size_of::<Vec<u8>>());
+    let _: Cow<[u32]> = numlist.list;
+}

--- a/tests/basic-proto/src/fixed_string_and_bytes.rs
+++ b/tests/basic-proto/src/fixed_string_and_bytes.rs
@@ -1,4 +1,4 @@
-use micropb::{FixedLenArray, FixedLenString, MessageDecode, MessageEncode, PbDecoder, PbEncoder};
+use micropb::{FixedLenString, MessageDecode, MessageEncode, PbDecoder, PbEncoder};
 
 mod proto {
     #![allow(clippy::all)]
@@ -12,9 +12,9 @@ fn string_bytes() {
     assert!(data.s().is_none());
     assert!(data.b().is_none());
     assert_eq!(&*data.s, "a\n\0");
-    assert_eq!(&*data.b, &[0x0, 0xFF]);
+    assert_eq!(&data.b, &[0x0, 0xFF]);
     let _: FixedLenString<3> = data.s;
-    let _: FixedLenArray<u8, 2> = data.b;
+    let _: [u8; 2] = data.b;
 }
 
 #[test]
@@ -30,20 +30,20 @@ fn decode_string_bytes() {
     let len = decoder.as_reader().len();
     data.decode(&mut decoder, len).unwrap();
     assert_eq!(&*data.s, "abc");
-    assert_eq!(&*data.b, &[1, 2]);
+    assert_eq!(&data.b, &[1, 2]);
 
     let mut decoder = PbDecoder::new([0x0A, 0, 0x12, 0].as_slice());
     let len = decoder.as_reader().len();
     data.decode(&mut decoder, len).unwrap();
     assert_eq!(&*data.s, "\0\0\0");
-    assert_eq!(&*data.b, &[1, 2]);
+    assert_eq!(&data.b, &[1, 2]);
 }
 
 #[test]
 fn encode_string_bytes() {
     let mut data = proto::Data::default();
     data.set_s(FixedLenString::try_from("abc").unwrap());
-    data.set_b(FixedLenArray::from([1, 2]));
+    data.set_b([1, 2]);
 
     let mut encoder = PbEncoder::new(vec![]);
     data.encode(&mut encoder).unwrap();

--- a/tests/basic-proto/src/lib.rs
+++ b/tests/basic-proto/src/lib.rs
@@ -9,6 +9,8 @@ mod container_alloc;
 #[cfg(test)]
 mod container_arrayvec;
 #[cfg(test)]
+mod container_cow;
+#[cfg(test)]
 mod container_heapless;
 #[cfg(test)]
 mod custom_field;

--- a/tests/basic-proto/src/lib.rs
+++ b/tests/basic-proto/src/lib.rs
@@ -40,3 +40,5 @@ mod no_config;
 mod recursive;
 #[cfg(test)]
 mod skip;
+#[cfg(test)]
+mod static_lifetime_fields;

--- a/tests/basic-proto/src/lifetime_fields.rs
+++ b/tests/basic-proto/src/lifetime_fields.rs
@@ -42,9 +42,16 @@ fn type_check() {
 
 #[test]
 fn ref_containers() {
+    // Declare data as local variables to ensure that the message fields are declared with
+    // non-static references
+    let b = b"123".to_owned();
+    let s = "abc".to_owned();
+    let list1 = [34, 150];
+    let list2 = ["ab", "cd"];
+
     let data = proto::Data {
-        b: b"123",
-        s: "abc",
+        b: b.as_ref(),
+        s: s.as_str(),
         _has: proto::Data_::_Hazzer::default().init_b().init_s(),
     };
     let list = proto::List { list: &[data] };
@@ -55,14 +62,12 @@ fn ref_containers() {
         &[0x0A, 10, 0x0A, 3, b'a', b'b', b'c', 0x12, 3, b'1', b'2', b'3']
     );
 
-    let num_list = proto::NumList { list: &[34, 150] };
+    let num_list = proto::NumList { list: &list1[..] };
     let mut encoder = PbEncoder::new(vec![]);
     num_list.encode(&mut encoder).unwrap();
     assert_eq!(encoder.as_writer(), &[0x08, 34, 0x08, 0x96, 0x01]);
 
-    let str_list = proto::StrList {
-        list: &["ab", "cd"],
-    };
+    let str_list = proto::StrList { list: &list2[..] };
     let mut encoder = PbEncoder::new(vec![]);
     str_list.encode(&mut encoder).unwrap();
     assert_eq!(

--- a/tests/basic-proto/src/lifetime_fields.rs
+++ b/tests/basic-proto/src/lifetime_fields.rs
@@ -26,11 +26,6 @@ impl FieldEncode for RefField<'_> {
 
 #[test]
 fn type_check() {
-    let nested = proto::nested_::Nested::<'_> {
-        inner: RefField(&5),
-    };
-    let _: RefField = nested.inner;
-
     let inner = proto::nested_::Nested_::InnerMsg {
         val: Default::default(),
         val2: Default::default(),
@@ -38,4 +33,7 @@ fn type_check() {
         _unknown: Some(RefField(&12)),
     };
     let _: Option<RefField> = inner._unknown;
+
+    let nested = proto::nested_::Nested::<'_> { inner: None };
+    let _: Option<proto::nested_::Nested_::Inner<'_>> = nested.inner;
 }

--- a/tests/basic-proto/src/lifetime_fields.rs
+++ b/tests/basic-proto/src/lifetime_fields.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use micropb::{FieldEncode, MessageEncode, PbEncoder};
 
 mod proto {
@@ -67,4 +69,11 @@ fn ref_containers() {
         encoder.as_writer(),
         &[0x0A, 2, b'a', b'b', 0x0A, 2, b'c', b'd']
     );
+
+    let map = proto::Map {
+        mapping: &HashMap::from([("x", b"y".as_slice())]),
+    };
+    let mut encoder = PbEncoder::new(vec![]);
+    map.encode(&mut encoder).unwrap();
+    assert_eq!(encoder.as_writer(), &[0xA, 6, 0xA, 1, b'x', 0x12, 1, b'y']);
 }

--- a/tests/basic-proto/src/static_lifetime_fields.rs
+++ b/tests/basic-proto/src/static_lifetime_fields.rs
@@ -1,0 +1,38 @@
+mod proto {
+    #![allow(clippy::all)]
+    #![allow(nonstandard_style, unused, irrefutable_let_patterns)]
+    include!(concat!(env!("OUT_DIR"), "/static_lifetime_fields.rs"));
+}
+
+// Ensure that the generated structs other than Data don't require lifetime params
+struct _Test {
+    data: proto::Data<'static>,
+    list: proto::List,
+    numlist: proto::NumList,
+    strlist: proto::StrList,
+    map: proto::Map,
+}
+
+#[test]
+fn ref_containers() {
+    // Check that it's possible to create Data with a non-static field `b`
+    let b = b"123".to_owned();
+    let data = proto::Data {
+        b: b.as_ref(),
+        s: "abc",
+        _has: proto::Data_::_Hazzer::default().init_b().init_s(),
+    };
+    let _: &'static str = data.s;
+
+    static LIST: &[proto::Data] = &[proto::Data {
+        b: b"123",
+        s: "abc",
+        _has: proto::Data_::_Hazzer::default().init_b().init_s(),
+    }];
+    let list = proto::List { list: LIST };
+    let _: &'static [proto::Data<'static>] = list.list;
+
+    static NUMLIST: &[u32] = &[13];
+    let numlist = proto::NumList { list: NUMLIST };
+    let _: &'static [u32] = numlist.list;
+}

--- a/tests/basic-proto/src/static_lifetime_fields.rs
+++ b/tests/basic-proto/src/static_lifetime_fields.rs
@@ -27,7 +27,7 @@ fn ref_containers() {
     static LIST: &[proto::Data] = &[proto::Data {
         b: b"123",
         s: "abc",
-        _has: proto::Data_::_Hazzer::default().init_b().init_s(),
+        _has: proto::Data_::_Hazzer::_new().init_b().init_s(),
     }];
     let list = proto::List { list: LIST };
     let _: &'static [proto::Data<'static>] = list.list;


### PR DESCRIPTION
- Add `PbBytes` trait
- Change definitions of all container traits
- Add `bytes_type` configuration
- Use string substitution in container types
- Fix lifetime detection for messages
- Add `field_lifetime` config for message fields